### PR TITLE
Add Bulk Check guidance page and controller stub

### DIFF
--- a/CheckChildcareEligibility.Admin/Controllers/BulkCheckController.cs
+++ b/CheckChildcareEligibility.Admin/Controllers/BulkCheckController.cs
@@ -279,4 +279,9 @@ public class BulkCheckController : BaseController
 
         return errorCount;
     }
+
+    public IActionResult Bulk_Check_Explainer()
+    {
+        return View();
+    }
 }

--- a/CheckChildcareEligibility.Admin/Views/BulkCheck/Bulk_Check_Explainer.cshtml
+++ b/CheckChildcareEligibility.Admin/Views/BulkCheck/Bulk_Check_Explainer.cshtml
@@ -1,0 +1,50 @@
+﻿@{
+    Layout = "~/Views/Shared/_Layout.cshtml";
+    ViewData["Title"] = "Batch check result explainer";
+}
+
+<div class="govuk-grid-column-two-thirds">
+    <a class="govuk-back-link" href="@Url.Action("Bulk_Check_Status", "BulkCheck")" onclick="history.back(); return false;">Back</a>
+    @* <a class="govuk-back-link-nolink"></a> *@
+
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-4">@ViewData["Title"]</h1>
+
+    <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
+        <div class="govuk-accordion__section">
+
+            <div class="govuk-accordion__section-header">
+                <h2 class="govuk-accordion__section-heading">
+                    <span class="govuk-accordion__section-button" id="accordion-default-heading-1">
+                        2 years old early learning
+                    </span>
+                </h2>
+            </div>
+
+            <div id="accordion-default-content-1" class="govuk-accordion__section-content"
+                 aria-labelledby="accordion-default-heading-1">
+                <p><strong>Eligible</strong> - The children of this parent or guardian are eligible for 2 years early learning.</p>
+                <p><strong>May not be eligible</strong> - The children of this parent or guardian may not be eligible for 2 years early learning. If they wish to appeal, ask the parent or guardian for evidence. <!-- <a href="#">View the list of acceptable evidence</a>. --></p>
+                <p><strong>Information does not match records</strong>  - This parent or guardian's personal information doesn't match the departmental records. Either their data was entered incorrectly or their entitlement isn't currently updated on the system.</p>
+                <p><strong>Try again</strong> - There was a problem accessing this parent or guardian's data to obtain a result. You should try again later.</p>
+            </div>
+        </div>
+
+        <div class="govuk-accordion__section">
+            <div class="govuk-accordion__section-header">
+                <h2 class="govuk-accordion__section-heading">
+                    <span class="govuk-accordion__section-button" id="accordion-default-heading-2">
+                        Early years pupil premium
+                    </span>
+                </h2>
+            </div>
+
+            <div id="accordion-default-content-2" class="govuk-accordion__section-content"
+                 aria-labelledby="accordion-default-heading-2">
+                <p><strong>Eligible</strong> - The children of this parent or guardian are eligible for 2 years early learning.</p>
+                <p><strong>May not be eligible</strong> - The children of this parent or guardian may not be eligible for 2 years early learning. If they wish to appeal, ask the parent or guardian for evidence. <!-- <a href="#">View the list of acceptable evidence</a>.--> </p>
+                <p><strong>Information does not match records</strong>  - This parent or guardian's personal information doesn't match the departmental records. Either their data was entered incorrectly or their entitlement isn't currently updated on the system.</p>
+                <p><strong>Try again</strong> - There was a problem accessing this parent or guardian's data to obtain a result. You should try again later.</p>
+            </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
I made presumption that the status page it is linked from will be called 'Bulk_Check_Status' for the back link on the guidance page, following nomenclature of other pages in the folder. 

[https://dfe-gov-uk.visualstudio.com/Solutions%20Development/_workitems/edit/214393](https://dfe-gov-uk.visualstudio.com/Solutions%20Development/_workitems/edit/214393)