### PR TITLE
QA-Fix-214388

### DIFF
--- a/CheckChildcareEligibility.Admin/Usecases/ParseBulkCheckFileUseCase.cs
+++ b/CheckChildcareEligibility.Admin/Usecases/ParseBulkCheckFileUseCase.cs
@@ -154,12 +154,26 @@ namespace CheckChildcareEligibility.Admin.Usecases
                     Message = $"CSV header error: {ex.Message}"
                 });
             }
-            catch (ReaderException ex)
+            catch (ReaderException ex) //Updated to userFriendlyMessage to stop leaking variable names to users
             {
+                string userFriendlyMessage;
+
+                if (ex.Message.Contains("No header record was found"))
+                {
+                    userFriendlyMessage = "The selected file is empty or missing headers.";
+                }
+                else if (ex.Message.Contains("data type"))
+                {
+                    userFriendlyMessage = $"CSV read error: The file contains invalid data at line {lineNumber}.";
+                }
+                else
+                {
+                    userFriendlyMessage = "CSV read error: An error occurred while processing the file.";
+                }
+
                 result.Errors.Add(new CsvRowError
                 {
-                    LineNumber = lineNumber,
-                    Message = $"CSV read error: {ex.Message}"
+                    Message = userFriendlyMessage
                 });
             }
             catch (Exception ex)

--- a/CheckChildcareEligibility.Admin/Views/BulkCheck/BulkOutcome/Error_Data_Issue.cshtml
+++ b/CheckChildcareEligibility.Admin/Views/BulkCheck/BulkOutcome/Error_Data_Issue.cshtml
@@ -5,7 +5,8 @@
 
 <div class="govuk-grid-column-full">
     <div id="content" data-type="ErrorData">
-        <a class="govuk-back-link-nolink"></a>
+        @Html.ActionLink("Back", "Index", "Home", null, new { @class = "govuk-back-link" })
+        @* <a class="govuk-back-link-nolink"></a> *@
 
         <div class="govuk-error-summary govuk-grid-column-full" data-module="govuk-error-summary">
             <div role="alert">

--- a/CheckChildcareEligibility.Admin/Views/BulkCheck/BulkOutcome/Error_Not_Accepted.cshtml
+++ b/CheckChildcareEligibility.Admin/Views/BulkCheck/BulkOutcome/Error_Not_Accepted.cshtml
@@ -4,7 +4,8 @@
 
 <div class="govuk-grid-column-full">
     <div id="content" data-type="ErrorNotAccepted">
-        <a class="govuk-back-link-nolink"></a>
+        @Html.ActionLink("Back", "Index", "Home", null, new { @class = "govuk-back-link" })
+        @* <a class="govuk-back-link-nolink"></a> *@
 
         <div class="govuk-error-summary govuk-grid-column-full" data-module="govuk-error-summary" data-type="success">
             <div role="alert">

--- a/CheckChildcareEligibility.Admin/Views/BulkCheck/BulkOutcome/Success.cshtml
+++ b/CheckChildcareEligibility.Admin/Views/BulkCheck/BulkOutcome/Success.cshtml
@@ -3,8 +3,8 @@
 }
 
 <div class="govuk-grid-column-full">
-    @* <a class="govuk-back-link" href="#" onclick="history.back(); return false;">Back</a> *@
-    <a class="govuk-back-link-nolink"></a>
+    @Html.ActionLink("Back", "Index", "Home", null, new { @class = "govuk-back-link" })
+    @* <a class="govuk-back-link-nolink"></a> *@
 
     <div id="content" data-type="success" class="govuk-grid-row">
         <div class="govuk-grid-column-full">


### PR DESCRIPTION
Add back links to dashboard for AC6/AC7 and add Error handling messages for empty file et al on ReaderException to avoid leaking variable names to end users on file error.

[https://dfe-gov-uk.visualstudio.com/Solutions%20Development/_boards/board/t/ECS/Stories?workitem=214388](https://dfe-gov-uk.visualstudio.com/Solutions%20Development/_boards/board/t/ECS/Stories?workitem=214388)