### PR TITLE
217204 Reconfirmation Status

### DIFF
--- a/CheckChildcareEligibility.Admin/Controllers/WorkingFamiliesCheckController.cs
+++ b/CheckChildcareEligibility.Admin/Controllers/WorkingFamiliesCheckController.cs
@@ -81,7 +81,7 @@ public class WorkingFamiliesCheckController : BaseController
         var eligibilityType = TempData.Peek("EligibilityType")?.ToString() ?? string.Empty;
 
         if (string.IsNullOrEmpty(eligibilityType))
-            return View("Outcome/Technical_Error");
+            return View("Outcome/Technical_Error_WF");
 
         if (string.Equals(eligibilityType, "WF", StringComparison.OrdinalIgnoreCase))
         {
@@ -136,7 +136,7 @@ public class WorkingFamiliesCheckController : BaseController
         }
         catch (Exception ex)
         {
-            return View("Outcome/Technical_Error");
+            return View("Outcome/Technical_Error_WF");
         }
     }
 

--- a/CheckChildcareEligibility.Admin/Domain/Constants/Generic/WorkingFamiliesResponseBanner.cs
+++ b/CheckChildcareEligibility.Admin/Domain/Constants/Generic/WorkingFamiliesResponseBanner.cs
@@ -15,7 +15,7 @@
         public const string CodeChildTooYoung = "Child is too young";
         public const string CodeVEDinFuture = "cannot be used yet";
         public const string CodeInGracePeriod = "in grace period";
-        public const string Expired = "Expired";
+        public const string CodeExpired = "Expired";
 
         public const string TermValidFrom = "Valid from";
         public const string TermValidFor = "Valid for";
@@ -26,7 +26,7 @@
         public const string SpringTerm = "spring term";
 
         public const string ReconfirmationBefore = "Needs reconfirming before";
-        public const string ReconfirmationNow = "Needs reconfirming now";
+        public const string ReconfirmationOverdue = "Needs reconfirming now";
         public const string ReconfirmationChildTooOld = "Child has reached compulsory school age";
         public const string ReconfirmationTempCode = "Apply for a new code before";
         public const string ReconfirmationTempCodeInGPED = "TBC";

--- a/CheckChildcareEligibility.Admin/Domain/Constants/Generic/WorkingFamiliesResponseDetails.cs
+++ b/CheckChildcareEligibility.Admin/Domain/Constants/Generic/WorkingFamiliesResponseDetails.cs
@@ -1,11 +1,20 @@
-﻿namespace CheckChildcareEligibility.Admin.Domain.Constants.Generic
+﻿using CheckChildcareEligibility.Admin.Models;
+using System.Security.Policy;
+
+namespace CheckChildcareEligibility.Admin.Domain.Constants.Generic
 {
     public static class WorkingFamiliesResponseDetails
     {
         public const string StatusNotApplicable = "Not applicable";
         public const string StatusNotDueYet = "Not due yet";
-        public static readonly string[] ReconfirmationStatusNotApplicable = {StatusNotApplicable,"yellow" };
-        public static readonly string[] ReconfirmationStatusNotDueYet = {StatusNotDueYet,"green" };
+        public const string StatusDueNow = "Due now";
+        public const string StatusOverdue = "Overdue";
+        public const string StatusChildTooOld = "Child too old";
+        public static readonly string[] ReconfirmationStatusNotApplicable = {StatusNotApplicable,"grey"};
+        public static readonly string[] ReconfirmationStatusNotDueYet = { StatusNotDueYet, "green"};
+        public static readonly string[] ReconfirmationStatusDueNow = { StatusDueNow, "yellow"};
+        public static readonly string[] ReconfirmationStatusOverdue = { StatusOverdue, "red"};
+        public static readonly string[] ReconfirmationStatusChildTooOld = { StatusChildTooOld, "grey"};
 
 
     }

--- a/CheckChildcareEligibility.Admin/ViewModels/WorkingFamiliesResponseViewModel.cs
+++ b/CheckChildcareEligibility.Admin/ViewModels/WorkingFamiliesResponseViewModel.cs
@@ -136,9 +136,9 @@ namespace CheckChildcareEligibility.Admin.ViewModels
 
         public string GetBannerReconfirmationMessage()
         {
-            if ((IsTemporaryCode && codeStatus == "valid")
-                || (IsTemporaryCode && codeStatus == "in grace period")
-                || (IsTemporaryCode && codeStatus == "expired"))
+            if ((IsTemporaryCode && codeStatus == WorkingFamiliesResponseBanner.CodeValid)
+                || (IsTemporaryCode && codeStatus == WorkingFamiliesResponseBanner.CodeInGracePeriod)
+                || (IsTemporaryCode && codeStatus == WorkingFamiliesResponseBanner.CodeExpired))
             {
                 return string.Empty;
             }

--- a/CheckChildcareEligibility.Admin/ViewModels/WorkingFamiliesResponseViewModel.cs
+++ b/CheckChildcareEligibility.Admin/ViewModels/WorkingFamiliesResponseViewModel.cs
@@ -22,12 +22,12 @@ namespace CheckChildcareEligibility.Admin.ViewModels
         public DateTime ValidityEndDate => DateTime.Parse(Response.ValidityEndDate);
         public DateTime GracePeriodEndDate => DateTime.Parse(Response.GracePeriodEndDate);
         public DateTime ChildDateOfBirth => DateTime.Parse(Response.DateOfBirth);
-        private DateTime startReconfirmDate => ValidityEndDate.AddDays(-28);
-        public int currentYear => DateTime.UtcNow.Year;
-        public string codeType = WorkingFamiliesResponseBanner.CodePermanent;
-        public string codeStatus = WorkingFamiliesResponseBanner.CodeValid;
-        public string bannerColour = WorkingFamiliesResponseBanner.ColourGreen;
-        public string termValidityDetails = WorkingFamiliesResponseBanner.TermValidFor;
+        private DateTime StartReconfirmDate => ValidityEndDate.AddDays(-28);
+        public int CurrentYear => DateTime.UtcNow.Year;
+        public string CodeType = WorkingFamiliesResponseBanner.CodePermanent;
+        public string CodeStatus = WorkingFamiliesResponseBanner.CodeValid;
+        public string BannerColour = WorkingFamiliesResponseBanner.ColourGreen;
+        public string TermValidityDetails = WorkingFamiliesResponseBanner.TermValidFor;
 
 
         public string Term
@@ -98,7 +98,7 @@ namespace CheckChildcareEligibility.Admin.ViewModels
             {
                 return WorkingFamiliesResponseBanner.ReconfirmationChildTooOld;
             }
-            else if (DateTime.Now >= startReconfirmDate && DateTime.Now <= ValidityEndDate) //due now
+            else if (DateTime.Now >= StartReconfirmDate && DateTime.Now <= ValidityEndDate) //due now
             {
                 return $"{WorkingFamiliesResponseBanner.ReconfirmationBefore} {ValidityEndDate.ToString("d MMMM yyyy")}";
             }
@@ -113,47 +113,47 @@ namespace CheckChildcareEligibility.Admin.ViewModels
         {
             if (IsTemporaryCode)
             {
-                codeType = WorkingFamiliesResponseBanner.CodeTemporary;
+                CodeType = WorkingFamiliesResponseBanner.CodeTemporary;
 
                 if (IsEligible)
                 {
-                    termValidityDetails = "Only" + termValidityDetails;
+                    TermValidityDetails = "Only" + TermValidityDetails;
                 }
             }
             else if (IsFosterCode)
             {
-                codeType = WorkingFamiliesResponseBanner.CodeFosterFamily;
+                CodeType = WorkingFamiliesResponseBanner.CodeFosterFamily;
             }
 
             if (IsEligible && ChildIsTooYoung) // Child too young
             {
-                codeStatus = WorkingFamiliesResponseBanner.CodeChildTooYoung;
-                bannerColour = WorkingFamiliesResponseBanner.ColourBlue;
-                termValidityDetails = WorkingFamiliesResponseBanner.TermValidFrom;
-                codeType = string.Empty;
+                CodeStatus = WorkingFamiliesResponseBanner.CodeChildTooYoung;
+                BannerColour = WorkingFamiliesResponseBanner.ColourBlue;
+                TermValidityDetails = WorkingFamiliesResponseBanner.TermValidFrom;
+                CodeType = string.Empty;
             }
             else if (IsVSDinFuture) // Validity start date in future
             {
-                codeStatus = WorkingFamiliesResponseBanner.CodeVEDinFuture;
-                bannerColour = WorkingFamiliesResponseBanner.ColourBlue;
+                CodeStatus = WorkingFamiliesResponseBanner.CodeVEDinFuture;
+                BannerColour = WorkingFamiliesResponseBanner.ColourBlue;
             }
             else if (IsInGracePeriod) // Code is in grace period
             {
-                codeStatus = WorkingFamiliesResponseBanner.CodeInGracePeriod;
-                bannerColour = WorkingFamiliesResponseBanner.ColourYellow;
+                CodeStatus = WorkingFamiliesResponseBanner.CodeInGracePeriod;
+                BannerColour = WorkingFamiliesResponseBanner.ColourYellow;
             }
             else if (IsExpired) // Expired
             {
-                codeStatus = WorkingFamiliesResponseBanner.CodeExpired;
-                bannerColour = WorkingFamiliesResponseBanner.ColourOrange;
+                CodeStatus = WorkingFamiliesResponseBanner.CodeExpired;
+                BannerColour = WorkingFamiliesResponseBanner.ColourOrange;
             }
         }
 
         public string GetBannerReconfirmationMessage()
         {
-            if ((IsTemporaryCode && codeStatus == WorkingFamiliesResponseBanner.CodeValid)
-                || (IsTemporaryCode && codeStatus == WorkingFamiliesResponseBanner.CodeInGracePeriod)
-                || (IsTemporaryCode && codeStatus == WorkingFamiliesResponseBanner.CodeExpired))
+            if ((IsTemporaryCode && CodeStatus == WorkingFamiliesResponseBanner.CodeValid)
+                || (IsTemporaryCode && CodeStatus == WorkingFamiliesResponseBanner.CodeInGracePeriod)
+                || (IsTemporaryCode && CodeStatus == WorkingFamiliesResponseBanner.CodeExpired))
             {
                 return string.Empty;
             }
@@ -161,7 +161,7 @@ namespace CheckChildcareEligibility.Admin.ViewModels
             {
                 return WorkingFamiliesResponseBanner.ReconfirmationChildTooOld;
             }
-            else if (DateTime.Now >= startReconfirmDate && DateTime.Now <= ValidityEndDate) //due now
+            else if (DateTime.Now >= StartReconfirmDate && DateTime.Now <= ValidityEndDate) //due now
             {
                 return $"{WorkingFamiliesResponseBanner.ReconfirmationBefore} {ValidityEndDate.ToString("d MMMM yyyy")}";
             }
@@ -182,11 +182,11 @@ namespace CheckChildcareEligibility.Admin.ViewModels
             {
                 return WorkingFamiliesResponseDetails.ReconfirmationStatusChildTooOld;
             }
-            else if (DateTime.Now < startReconfirmDate)
+            else if (DateTime.Now < StartReconfirmDate)
             {
                 return WorkingFamiliesResponseDetails.ReconfirmationStatusNotDueYet;
             }
-            else if (DateTime.Now >= startReconfirmDate && DateTime.Now <= ValidityEndDate) //due now
+            else if (DateTime.Now >= StartReconfirmDate && DateTime.Now <= ValidityEndDate) //due now
             {
                 return WorkingFamiliesResponseDetails.ReconfirmationStatusDueNow;
             }

--- a/CheckChildcareEligibility.Admin/Views/Shared/_CheckResponseBannerPartial.cshtml
+++ b/CheckChildcareEligibility.Admin/Views/Shared/_CheckResponseBannerPartial.cshtml
@@ -2,62 +2,17 @@
 @model CheckChildcareEligibility.Admin.ViewModels.WorkingFamiliesResponseViewModel
 
 @{
-    int currentYear = DateTime.UtcNow.Year;
-    // defaults
-    string codeType = WorkingFamiliesResponseBanner.CodePermanent;
-    string codeStatus = WorkingFamiliesResponseBanner.CodeValid;
-    string bannerColour = WorkingFamiliesResponseBanner.ColourGreen;
-    string termValidityDetails = WorkingFamiliesResponseBanner.TermValidFor;
-    string reconfirmationDetails = $"{WorkingFamiliesResponseBanner.ReconfirmationBefore} {Model.ValidityEndDate.ToString("d MMMM yyyy")}";
-
-    if (Model.IsTemporaryCode)
-    {
-        codeType = WorkingFamiliesResponseBanner.CodeTemporary;
-
-        if (Model.IsEligible)
-        {
-            termValidityDetails = "Only" + termValidityDetails;
-        }
-    }
-    else if (Model.IsFosterCode)
-    {
-        codeType = WorkingFamiliesResponseBanner.CodeFosterFamily;
-    }
-    // Child too young
-    if (Model.IsEligible && Model.ChildIsTooYoung)
-    {
-        codeStatus = WorkingFamiliesResponseBanner.CodeChildTooYoung;
-        bannerColour = WorkingFamiliesResponseBanner.ColourBlue;
-        termValidityDetails = WorkingFamiliesResponseBanner.TermValidFrom;
-        codeType = string.Empty;
-    }
-    // Validity start date in future
-    else if (Model.IsVSDinFuture)
-    {
-        codeStatus = WorkingFamiliesResponseBanner.CodeVEDinFuture;
-        bannerColour = WorkingFamiliesResponseBanner.ColourBlue;
-    }
-    // Code is in grace period
-    else if (Model.IsInGracePeriod)
-    {
-        codeStatus = WorkingFamiliesResponseBanner.CodeInGracePeriod;
-        bannerColour = WorkingFamiliesResponseBanner.ColourYellow;
-    }
-    // Expired
-    else if (Model.IsExpired)
-    {
-        codeStatus = WorkingFamiliesResponseBanner.Expired;
-        bannerColour = WorkingFamiliesResponseBanner.ColourOrange;
-    }
+    string bannerReconfirmationMessage = Model.GetBannerReconfirmationMessage();
 }
-<div class="govuk-panel govuk-panel--@bannerColour govuk-!-margin-bottom-7">
+
+<div class="govuk-panel govuk-panel--@Model.bannerColour govuk-!-margin-bottom-7">
     <h1 class="govuk-panel__title">
-        @codeType @codeStatus
+        @Model.codeType @Model.codeStatus
     </h1>
     <div class="govuk-panel__body govuk-!-margin-bottom-5">
-       @termValidityDetails @Model.Term @currentYear
+        @Model.termValidityDetails @Model.Term @Model.currentYear
     </div>
     <div class="govuk-body-l govuk-!-margin-bottom-0">
-        @reconfirmationDetails
+        @bannerReconfirmationMessage
     </div>
 </div>

--- a/CheckChildcareEligibility.Admin/Views/Shared/_CheckResponseBannerPartial.cshtml
+++ b/CheckChildcareEligibility.Admin/Views/Shared/_CheckResponseBannerPartial.cshtml
@@ -5,12 +5,12 @@
     string bannerReconfirmationMessage = Model.GetBannerReconfirmationMessage();
 }
 
-<div class="govuk-panel govuk-panel--@Model.bannerColour govuk-!-margin-bottom-7">
+<div class="govuk-panel govuk-panel--@Model.BannerColour govuk-!-margin-bottom-7">
     <h1 class="govuk-panel__title">
-        @Model.codeType @Model.codeStatus
+        @Model.CodeType @Model.CodeStatus
     </h1>
     <div class="govuk-panel__body govuk-!-margin-bottom-5">
-       @Model.termValidityDetails @Model.Term
+       @Model.TermValidityDetails @Model.Term
     </div>
     <div class="govuk-body-l govuk-!-margin-bottom-0">
         @bannerReconfirmationMessage

--- a/CheckChildcareEligibility.Admin/Views/Shared/_CheckResponseDetailsPartial.cshtml
+++ b/CheckChildcareEligibility.Admin/Views/Shared/_CheckResponseDetailsPartial.cshtml
@@ -4,14 +4,14 @@
 @{
     DateTime startReconfirmDate = Model.ValidityEndDate.AddDays(-28);
     string reconfirmBetween = $"{startReconfirmDate.ToString("d MMMM yyyy")} and {Model.ValidityEndDate.ToString("d MMMM yyyy")}";
-    string[] reconfirmationStatus = WorkingFamiliesResponseDetails.ReconfirmationStatusNotDueYet; 
+    string[] reconfirmationStatus = Model.GetReconfirmationStatus();
 
     if (Model.IsTemporaryCode || Model.ChildIsTooYoung)
     {
         reconfirmBetween = WorkingFamiliesResponseDetails.StatusNotApplicable;
-    } 
-   
+    }
 }
+
 <h2 class="govuk-heading-m">Details checked</h2>
 <dl class="govuk-summary-list">
     <div class="govuk-summary-list__row">

--- a/CheckChildcareEligibility.Admin/Views/WorkingFamiliesCheck/Outcome/Response_WF.cshtml
+++ b/CheckChildcareEligibility.Admin/Views/WorkingFamiliesCheck/Outcome/Response_WF.cshtml
@@ -1,19 +1,25 @@
 ﻿@model CheckChildcareEligibility.Admin.ViewModels.WorkingFamiliesResponseViewModel
 
-<div class="govuk-width-container">
-    <main class="govuk-main-wrapper" id="main-content">
-        <div class="govuk-grid-row">
-            <div class="govuk-grid-column-two-thirds">
-                <partial name="_CheckResponseBannerPartial" model="Model">
-                <partial name="_CheckResponseDetailsPartial" model="Model">
+@{
+    Model.SetBannerValues();
+    ViewData["Title"] = Model.codeType;
+}
 
-                <p>You can <a href="" class="govuk-link" onclick="printPage()">print this page</a> for the parent or guardian to keep.</p>
+<div class="govuk-grid-column-full">
+    @* <a class="govuk-back-link" href="#" onclick="history.back(); return false;">Back</a> *@
+    <a class="govuk-back-link-nolink"></a>
+
+    <div class="govuk-width-container">
+        <main class="govuk-main-wrapper" id="main-content">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-two-thirds">
+                    <partial name="_CheckResponseBannerPartial" model="Model">
+                        <partial name="_CheckResponseDetailsPartial" model="Model">
+                            <p>You can <a href="#" id="print-link" class="govuk-link">print this page</a> for the parent or guardian to keep.</p>
+                </div>
             </div>
-        </div>
-        <script>
-            function printPage() {
-                window.print();  // This will open the print dialog. Need to revisit
-            }
-        </script>
-    </main>
+        </main>
+    </div>
 </div>
+
+<script src="~/js/site.js"></script>

--- a/CheckChildcareEligibility.Admin/Views/WorkingFamiliesCheck/Outcome/Response_WF.cshtml
+++ b/CheckChildcareEligibility.Admin/Views/WorkingFamiliesCheck/Outcome/Response_WF.cshtml
@@ -2,7 +2,7 @@
 
 @{
     Model.SetBannerValues();
-    ViewData["Title"] = Model.codeType;
+    ViewData["Title"] = Model.CodeType;
 }
 
 <div class="govuk-grid-column-full">

--- a/CheckChildcareEligibility.Admin/wwwroot/css/site.css
+++ b/CheckChildcareEligibility.Admin/wwwroot/css/site.css
@@ -365,7 +365,7 @@ img, svg {
 /*BEGIN - different colours for WF outcomes banner */
 
 .govuk-panel--yellow {
-    color: #ffffff;
+    color: #000000;
     background: #ffdd00;
 }
 
@@ -375,7 +375,7 @@ img, svg {
 }
 
 .govuk-panel--orange {
-    color: #ffffff;
+    color: #000000;
     background: #f47738;
 }
 .govuk-panel--confirmation > div {


### PR DESCRIPTION
Move logic from partials to view model. Add to existing logic for reconfirmation status, banner messages and colours.

[https://dfe-gov-uk.visualstudio.com/Solutions%20Development/_workitems/edit/217204](https://dfe-gov-uk.visualstudio.com/Solutions%20Development/_workitems/edit/217204)

Note: When testing the check date cannot be changed so tests must be designed around that.
There is a process to run the API locally and a dev proxy which allows you to define the server data manually. See Anoop who set this up originally for further info if required.