### PR TITLE
238048-CHILDCARE-HideCookiesSettingsWhenJavaScriptDisabled

### DIFF
--- a/CheckChildcareEligibility.Admin/Views/Home/Cookies.cshtml
+++ b/CheckChildcareEligibility.Admin/Views/Home/Cookies.cshtml
@@ -9,8 +9,10 @@
 
     <h1 class="govuk-heading-l govuk-!-margin-bottom-4">@ViewData["Title"]</h1>
 
-    <p>The Check if a child can get free school meals service puts small files (known as ‘cookies’) onto your computer
-        to collect information about how you browse the site. </p>
+    <p>
+        The Check if a child can get free school meals service puts small files (known as ‘cookies’) onto your computer
+        to collect information about how you browse the site.
+    </p>
 
     <p>Cookies are used to:</p>
     <ul class="govuk-list govuk-list--bullet">
@@ -19,8 +21,10 @@
         <li>store various settings you have selected so they will be used when you return to the site.</li>
     </ul>
 
-    <p>GOV.UK cookies aren’t used to identify you personally. You’ll normally see a message on the site before we store
-        a cookie on your computer.</p>
+    <p>
+        GOV.UK cookies aren’t used to identify you personally. You’ll normally see a message on the site before we store
+        a cookie on your computer.
+    </p>
 
     <p>Find out more about <a href="http://www.aboutcookies.org/">how to manage cookies</a>. </p>
 
@@ -28,8 +32,10 @@
 
     <h2 class="govuk-heading-m govuk-!-margin-top-6">Measuring website usage (Google Analytics)</h2>
 
-    <p>We use Google Analytics software to collect information about how you use GOV.UK. We do this to help make sure
-        the site is meeting the needs of its users and to help us make improvements.</p>
+    <p>
+        We use Google Analytics software to collect information about how you use GOV.UK. We do this to help make sure
+        the site is meeting the needs of its users and to help us make improvements.
+    </p>
 
     <p>Google Analytics stores information about:</p>
     <ul class="govuk-list govuk-list--bullet">
@@ -39,86 +45,92 @@
         <li>what you click on while you’re visiting the site</li>
     </ul>
 
-    <p>We don’t collect or store your personal information (for example, your name or address) so this information can’t
-        be used to identify who you are.</p>
+    <p>
+        We don’t collect or store your personal information (for example, your name or address) so this information can’t
+        be used to identify who you are.
+    </p>
 
     <p>We don’t allow Google to use or share our analytics data. </p>
 
     <p>Google Analytics sets the following cookies: </p>
     <table class="govuk-table">
         <thead class="govuk-table__head">
-        <tr class="govuk-table__row">
-            <th scope="col" class="govuk-table__header">Name</th>
-            <th scope="col" class="govuk-table__header">Purpose</th>
-            <th scope="col" class="govuk-table__header">Expires</th>
-        </tr>
+            <tr class="govuk-table__row">
+                <th scope="col" class="govuk-table__header">Name</th>
+                <th scope="col" class="govuk-table__header">Purpose</th>
+                <th scope="col" class="govuk-table__header">Expires</th>
+            </tr>
         </thead>
         <tbody class="govuk-table__body">
-        <tr class="govuk-table__row">
-            <td class="govuk-table__cell">_ga</td>
-            <td class="govuk-table__cell">Google Analytics sets the following cookies:</td>
-            <td class="govuk-table__cell">2 years</td>
-        </tr>
-        <tr class="govuk-table__row">
-            <td class="govuk-table__cell">_gid</td>
-            <td class="govuk-table__cell">This helps us count how many people visit GOV.UK by tracking if you’ve visited
-                before
-            </td>
-            <td class="govuk-table__cell">24 hours</td>
-        </tr>
-        <tr class="govuk-table__row">
-            <td class="govuk-table__cell">_ga_9YG8ESXR5Y</td>
-            <td class="govuk-table__cell">Used by Google Analytics to find and track an individual session with your
-                device
-            </td>
-            <td class="govuk-table__cell">2 years</td>
-        </tr>
+            <tr class="govuk-table__row">
+                <td class="govuk-table__cell">_ga</td>
+                <td class="govuk-table__cell">Google Analytics sets the following cookies:</td>
+                <td class="govuk-table__cell">2 years</td>
+            </tr>
+            <tr class="govuk-table__row">
+                <td class="govuk-table__cell">_gid</td>
+                <td class="govuk-table__cell">
+                    This helps us count how many people visit GOV.UK by tracking if you’ve visited
+                    before
+                </td>
+                <td class="govuk-table__cell">24 hours</td>
+            </tr>
+            <tr class="govuk-table__row">
+                <td class="govuk-table__cell">_ga_9YG8ESXR5Y</td>
+                <td class="govuk-table__cell">
+                    Used by Google Analytics to find and track an individual session with your
+                    device
+                </td>
+                <td class="govuk-table__cell">2 years</td>
+            </tr>
         </tbody>
     </table>
     <p>You can <a href="https://tools.google.com/dlpage/gaoptout">opt out of Google Analytics cookies</a>. </p>
 
     <h2 class="govuk-heading-m govuk-!-margin-top-6">Our introductory message </h2>
 
-    <p>You may see a pop-up welcome message when you first visit GOV.UK. We’ll store a cookie so that your computer
-        knows you’ve seen it and knows not to show it again. </p>
+    <p>
+        You may see a pop-up welcome message when you first visit GOV.UK. We’ll store a cookie so that your computer
+        knows you’ve seen it and knows not to show it again.
+    </p>
 
     <table class="govuk-table" aria-label="Cookies that measure website usage">
         <thead class="govuk-table__head">
-        <tr>
-            <th scope="col" class="govuk-table__header">
-                Name
-            </th>
-            <th scope="col" class="govuk-table__header">
-                Purpose
-            </th>
-            <th scope="col" class="govuk-table__header">
-                Expires
-            </th>
-        </tr>
+            <tr>
+                <th scope="col" class="govuk-table__header">
+                    Name
+                </th>
+                <th scope="col" class="govuk-table__header">
+                    Purpose
+                </th>
+                <th scope="col" class="govuk-table__header">
+                    Expires
+                </th>
+            </tr>
         </thead>
         <tbody class="govuk-table__body">
-        <tr>
-            <td class="govuk-table__cell">
-                ees_banner_seen
-            </td>
-            <td class="govuk-table__cell">
-                Saves a message to let us know that you’ve seen our cookie message
-            </td>
-            <td class="govuk-table__cell">
-                1 year
-            </td>
-        </tr>
-        <tr>
-            <td class="govuk-table__cell">
-                ees_user_testing_banner_seen
-            </td>
-            <td class="govuk-table__cell">
-                Saves a message to let us know that you’ve seen our user testing invite message
-            </td>
-            <td class="govuk-table__cell">
-                1 year
-            </td>
-        </tr>
+            <tr>
+                <td class="govuk-table__cell">
+                    ees_banner_seen
+                </td>
+                <td class="govuk-table__cell">
+                    Saves a message to let us know that you’ve seen our cookie message
+                </td>
+                <td class="govuk-table__cell">
+                    1 year
+                </td>
+            </tr>
+            <tr>
+                <td class="govuk-table__cell">
+                    ees_user_testing_banner_seen
+                </td>
+                <td class="govuk-table__cell">
+                    Saves a message to let us know that you’ve seen our user testing invite message
+                </td>
+                <td class="govuk-table__cell">
+                    1 year
+                </td>
+            </tr>
         </tbody>
     </table>
 
@@ -126,40 +138,46 @@
         <div class="govuk-grid-column-two-thirds">
             <h2 class="govuk-heading-m govuk-!-margin-top-6">Your cookie settings</h2>
 
-            <p>We will store your cookie settings as a cookie, so that they remain if you return to GOV.UK: Explore
-                education statistics. </p>
+            <p>
+                We will store your cookie settings as a cookie, so that they remain if you return to GOV.UK: Explore
+                education statistics.
+            </p>
 
             <table class="govuk-table" aria-label="Cookies that measure website usage">
                 <thead class="govuk-table__head">
-                <tr>
-                    <th scope="col" class="govuk-table__header">
-                        Name
-                    </th>
-                    <th scope="col" class="govuk-table__header">
-                        Purpose
-                    </th>
-                    <th scope="col" class="govuk-table__header">
-                        Expires
-                    </th>
-                </tr>
+                    <tr>
+                        <th scope="col" class="govuk-table__header">
+                            Name
+                        </th>
+                        <th scope="col" class="govuk-table__header">
+                            Purpose
+                        </th>
+                        <th scope="col" class="govuk-table__header">
+                            Expires
+                        </th>
+                    </tr>
                 </thead>
                 <tbody class="govuk-table__body">
-                <tr>
-                    <td class="govuk-table__cell">
-                        ees_disable_google_analytics
-                    </td>
-                    <td class="govuk-table__cell">
-                        Disables Google Analytics tracking
-                    </td>
-                    <td class="govuk-table__cell">
-                        10 years
-                    </td>
-                </tr>
+                    <tr>
+                        <td class="govuk-table__cell">
+                            ees_disable_google_analytics
+                        </td>
+                        <td class="govuk-table__cell">
+                            Disables Google Analytics tracking
+                        </td>
+                        <td class="govuk-table__cell">
+                            10 years
+                        </td>
+                    </tr>
                 </tbody>
             </table>
 
-            <p>You can <a href="https://explore-education-statistics.service.gov.uk/cookies">change which cookies you're
-                    happy for us to use</a>.</p>
+            <p>
+                You can <a href="https://explore-education-statistics.service.gov.uk/cookies">
+                    change which cookies you're
+                    happy for us to use
+                </a>.
+            </p>
         </div>
     </div>
 
@@ -171,41 +189,41 @@
 
             <table class="govuk-table" aria-label="Cookies that measure website usage">
                 <thead class="govuk-table__head">
-                <tr>
-                    <th scope="col" class="govuk-table__header">
-                        Name
-                    </th>
-                    <th scope="col" class="govuk-table__header">
-                        Purpose
-                    </th>
-                    <th scope="col" class="govuk-table__header">
-                        Expires
-                    </th>
-                </tr>
+                    <tr>
+                        <th scope="col" class="govuk-table__header">
+                            Name
+                        </th>
+                        <th scope="col" class="govuk-table__header">
+                            Purpose
+                        </th>
+                        <th scope="col" class="govuk-table__header">
+                            Expires
+                        </th>
+                    </tr>
                 </thead>
                 <tbody class="govuk-table__body">
-                <tr>
-                    <td class="govuk-table__cell">
-                        ai_user
-                    </td>
-                    <td class="govuk-table__cell">
-                        Used to identify returning users
-                    </td>
-                    <td class="govuk-table__cell">
-                        1 year
-                    </td>
-                </tr>
-                <tr>
-                    <td class="govuk-table__cell">
-                        ai_sessionx
-                    </td>
-                    <td class="govuk-table__cell">
-                        Anonymous session identifer to group a user's activities
-                    </td>
-                    <td class="govuk-table__cell">
-                        15 minutes
-                    </td>
-                </tr>
+                    <tr>
+                        <td class="govuk-table__cell">
+                            ai_user
+                        </td>
+                        <td class="govuk-table__cell">
+                            Used to identify returning users
+                        </td>
+                        <td class="govuk-table__cell">
+                            1 year
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="govuk-table__cell">
+                            ai_sessionx
+                        </td>
+                        <td class="govuk-table__cell">
+                            Anonymous session identifer to group a user's activities
+                        </td>
+                        <td class="govuk-table__cell">
+                            15 minutes
+                        </td>
+                    </tr>
                 </tbody>
             </table>
         </div>
@@ -219,59 +237,62 @@
 
             <table class="govuk-table" aria-label="Cookies that measure website usage">
                 <thead class="govuk-table__head">
-                <tr>
-                    <th scope="col" class="govuk-table__header">
-                        Name
-                    </th>
-                    <th scope="col" class="govuk-table__header">
-                        Purpose
-                    </th>
-                    <th scope="col" class="govuk-table__header">
-                        Expires
-                    </th>
-                </tr>
+                    <tr>
+                        <th scope="col" class="govuk-table__header">
+                            Name
+                        </th>
+                        <th scope="col" class="govuk-table__header">
+                            Purpose
+                        </th>
+                        <th scope="col" class="govuk-table__header">
+                            Expires
+                        </th>
+                    </tr>
                 </thead>
                 <tbody class="govuk-table__body">
-                <tr>
-                    <td class="govuk-table__cell">
-                    </td>
-                    <td class="govuk-table__cell">
-                    </td>
-                    <td class="govuk-table__cell">
-                    </td>
-                </tr>
+                    <tr>
+                        <td class="govuk-table__cell">
+                        </td>
+                        <td class="govuk-table__cell">
+                        </td>
+                        <td class="govuk-table__cell">
+                        </td>
+                    </tr>
                 </tbody>
             </table>
         </div>
-        <div class="govuk-grid-row">
-            <div class="govuk-grid-column-two-thirds">
-                <h2 class="govuk-heading-l">Change your cookie settings</h2>
-                <form id="cookie-form" action="/form-handler" method="post" novalidate>
-                    <div class="govuk-form-group">
-                        <fieldset class="govuk-fieldset">
-                            <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
-                                Do you want to accept analytics cookies?
-                            </legend>
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="cookies-analytics-yes" name="cookies[analytics]" type="radio" value="yes">
-                                    <label class="govuk-label govuk-radios__label" for="cookies-analytics-yes">
-                                        Yes
-                                    </label>
+
+        <div class="js-only">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-two-thirds">
+                    <h2 class="govuk-heading-l">Change your cookie settings</h2>
+                    <form id="cookie-form" action="/form-handler" method="post" novalidate>
+                        <div class="govuk-form-group">
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+                                    Do you want to accept analytics cookies?
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="cookies-analytics-yes" name="cookies[analytics]" type="radio" value="yes">
+                                        <label class="govuk-label govuk-radios__label" for="cookies-analytics-yes">
+                                            Yes
+                                        </label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="cookies-analytics-no" name="cookies[analytics]" type="radio" value="no" checked>
+                                        <label class="govuk-label govuk-radios__label" for="cookies-analytics-no">
+                                            No
+                                        </label>
+                                    </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="cookies-analytics-no" name="cookies[analytics]" type="radio" value="no" checked>
-                                    <label class="govuk-label govuk-radios__label" for="cookies-analytics-no">
-                                        No
-                                    </label>
-                                </div>
-                            </div>
-                        </fieldset>
-                    </div>
-                    <button type="submit" class="govuk-button" data-module="govuk-button">
-                        Save cookie settings
-                    </button>
-                </form>
+                            </fieldset>
+                        </div>
+                        <button type="submit" class="govuk-button" data-module="govuk-button">
+                            Save cookie settings
+                        </button>
+                    </form>
+                </div>
             </div>
         </div>
     </div>

--- a/CheckChildcareEligibility.Admin/wwwroot/css/site.css
+++ b/CheckChildcareEligibility.Admin/wwwroot/css/site.css
@@ -66,12 +66,9 @@
     padding-left: 0.875em;
     text-decoration: underline max(1px, 0.0625rem);
 }
-
 /*END - back button overrides */
 
-
 /*BEGIN - Header account links */
-
 #content-header .dfe-header__action-links a,
 #content-header .dfe-header__action-links a:visited,
 #content-header .dfe-header__action-links a:active {
@@ -86,11 +83,9 @@
 .govuk-pagination {
     justify-content: center;
 }
-
 /*END - Header account links */
 
 /*BEGIN - dashboard card overrides */
-
 .dfe-card {
     position: relative;
     display: flex;
@@ -182,11 +177,9 @@
     .button-as-link-dfe-card-style:hover {
         color: #ffffff;
     }
-
 /*END - dashboard card overrides */
 
 /*BEGIN - Accessible dashboard card links */
-
 .sr-only {
     position: absolute;
     width: 1px;
@@ -197,11 +190,10 @@
     clip: rect(0, 0, 0, 0);
     border: 0;
 }
-
 /*END - Accessible dashboard card links */
 
 
-/* MENU ITEM */
+/* BEGIN MENU ITEM */
 .moj-button-menu__item {
     display: inline-block;
     margin-right: 10px;
@@ -212,12 +204,10 @@
     .moj-button-menu__item:last-child {
         margin-right: 0;
     }
-
 /* END MENU ITEM */
 
 
 /*BEGIN - Header overrides */
-
 .dfe-header__container {
     padding: 0;
     padding-top: 20px;
@@ -279,31 +269,25 @@ img, svg {
         max-width: 100%;
     }
 }
-
 /*END - Header overrides */
 
 
 /*BEGIN - Child Details form title width extention override */
-
 @media (min-width: 40.0625em) {
     .govuk-summary-list__key {
         width: 45%; /*to fit NIN/ASRN title*/
     }
 }
-
 /*END - Child Details form title width extention override */
 
 
 /*BEGIN - Remove whitespace from ApplicationDetailLA below name and actions */
-
 .whitespaceDelete {
     margin-bottom: 0;
 }
-
 /*END - Remove whitespace from ApplicationDetailLA below name and actions */
 
 /*BEGIN - Inline style replace for search all records design team customised styles */
-
 .govuk-page-header-customisation {
     display: flex;
     align-items: center;
@@ -313,20 +297,16 @@ img, svg {
 .govuk-heading-m-customisation {
     margin: 0;
 }
-
 /*END - Inline style replace for search all records design team customised styles */
 
 /*BEGIN - Force thumbnail container width on Home/FSMFormDownload to avoid text overlap on page resize */
-
 .fsm-image {
     min-width: 175px;
 }
-
 /*END - Force thumbnail container width on Home/FSMFormDownload to avoid text overlap on page resize */
 
 
 /*BEGIN - Style a button as a link */
-
 .button-as-link-style {
     background: none;
     border: none;
@@ -335,22 +315,18 @@ img, svg {
     cursor: pointer;
     /*    font-size: inherit;*/
 }
-
 /*END - Force thumbnail container width on Home/FSMFormDownload to avoid text overlap on page resize */
 
 /*BEGIN - Align right and set correct margin for 'Remove' link on Evidence Upload Items */
-
 .alignRight {
     text-align: right;
     display: block;
     margin-right: -5px;
 }
-
 /*END - Align right and set correct margin for 'Remove' link on Evidence Upload Items */
 
 
 /*BEGIN - set dfe card width to match prototype */
-
 @media (min-width: 40.0625em) {
     .dfe-grid-container {
         display: grid;
@@ -358,12 +334,10 @@ img, svg {
         gap: 30px;
     }
 }
-
 /*END - set dfe card width to match prototype */
 
 
 /*BEGIN - different colours for WF outcomes banner */
-
 .govuk-panel--yellow {
     color: #000000;
     background: #ffdd00;
@@ -382,9 +356,19 @@ img, svg {
     color: #ffffff !important;
 }
 /*END - different colours for WF outcomes banner */
+
 /*BEGIN - 224933 WF/2YO/EYPP - Update default fonts on childcare pages */
 * {
     font-family: 'Inter', sans-serif !important;
 }
-
 /*END - 224933 WF/2YO/EYPP - Update default fonts on childcare pages */
+
+/*BEGIN - Class with associated JS function in cookieFunctions.js to show content when JS is enabled */
+.js-only {
+    display: none;
+}
+
+.show {
+    display: block;
+}
+/*END - Class with associated JS function in cookieFunctions.js to show content when JS is enabled */

--- a/CheckChildcareEligibility.Admin/wwwroot/js/site.js
+++ b/CheckChildcareEligibility.Admin/wwwroot/js/site.js
@@ -13,3 +13,8 @@ function printPage() {
     window.print();
 }
 //END-- Summon print dialogue from a link
+
+//BEGIN-- Can show elements only when JavaScript is enabled by using this class on the element
+document.querySelectorAll('.js-only').forEach(x => x.classList.add("show"))
+//END-- Can show elements only when JavaScript is enabled by using this class on the element
+


### PR DESCRIPTION
Hide the Cookie Consent form for non JS enabled users. Also re-useable JS and CSS for other elements requiring this ability.
