### PR TITLE
Elig 404 ff create new tile for manage foster family in dashboard

### DIFF
--- a/CheckChildcareEligibility.Admin.Tests/Controllers/HomeControllerTests.cs
+++ b/CheckChildcareEligibility.Admin.Tests/Controllers/HomeControllerTests.cs
@@ -239,6 +239,20 @@ internal class HomeControllerTests
     }
 
     [Test]
+    public void Given_ManageFosterFamilies_Get_ReturnsView()
+    {
+        // Arrange
+
+        // Act
+        var result = _sut.ManageFosterFamilies();
+
+        // Assert
+        var viewResult = result as ViewResult;
+        viewResult.Should().NotBeNull();
+        viewResult.ViewName.Should().Be("ManageFosterFamilies");
+    }
+
+    [Test]
     public void Given_Guidance_ReturnsView()
     {
         // Act

--- a/CheckChildcareEligibility.Admin/Controllers/HomeController.cs
+++ b/CheckChildcareEligibility.Admin/Controllers/HomeController.cs
@@ -116,6 +116,11 @@ public class HomeController : BaseController
         return View("GuidanceHome");
     }
 
+    public IActionResult ManageFosterFamilies()
+    {
+        return View("ManageFosterFamilies");
+    }
+
     public IActionResult FSMFormDownload()
     {
         return View("FSMFormDownload");

--- a/CheckChildcareEligibility.Admin/Views/Home/Index.cshtml
+++ b/CheckChildcareEligibility.Admin/Views/Home/Index.cshtml
@@ -49,6 +49,16 @@
                         <p>Read guidance on running eligibility checks and managing foster families.</p>
                     </div>
                 </div>
+
+                <div class="dfe-card">
+                    <div class="dfe-card-container">
+                        <h2 class="govuk-heading-m">
+                            <a class="govuk-link govuk-link--no-visited-state dfe-card-link--header"
+                               href="@Url.Action("ManageFosterFamilies", "Home")">Manage foster families</a>
+                        </h2>
+                        <p>Manage foster families claiming Childcare for working families.</p>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/CheckChildcareEligibility.Admin/Views/Home/ManageFosterFamilies.cshtml
+++ b/CheckChildcareEligibility.Admin/Views/Home/ManageFosterFamilies.cshtml
@@ -1,0 +1,3 @@
+﻿@{
+    ViewData["Title"] = "Manage foster families";
+}


### PR DESCRIPTION
Adds a new “Manage foster families” tile to the Childcare dashboard.

- Introduces a new HomeController action for ManageFosterFamilies
- Adds an empty view to support navigation without runtime errors
- Updates the dashboard to display the new tile, matching existing card patterns
- Adds a controller unit test for the new action

No permissions or feature behaviour changes included.
