### PR TITLE
ELIG-2879-CHILDCARE-Ensure-screen-reader-users-can-distinguish-between-page-sections-by-giving-each-landmark-a-unique-name

### DIFF
--- a/CheckChildcareEligibility.Admin/Views/Shared/_Cookies.cshtml
+++ b/CheckChildcareEligibility.Admin/Views/Shared/_Cookies.cshtml
@@ -130,35 +130,37 @@
 </div>
 
 <div class="js-only">
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-            <h2 class="govuk-heading-l">Change your cookie settings</h2>
-            <form id="cookie-form" action="/form-handler" method="post" novalidate>
-                <div class="govuk-form-group">
-                    <fieldset class="govuk-fieldset">
-                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
-                            Do you want to accept analytics cookies?
-                        </legend>
-                        <div class="govuk-radios" data-module="govuk-radios">
-                            <div class="govuk-radios__item">
-                                <input class="govuk-radios__input" id="cookies-analytics-yes" name="cookies[analytics]" type="radio" value="yes">
-                                <label class="govuk-label govuk-radios__label" for="cookies-analytics-yes">
-                                    Yes
-                                </label>
+    <div class="govuk-grid-column-two-thirds">
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-two-thirds">
+                <h2 class="govuk-heading-l">Change your cookie settings</h2>
+                <form id="cookie-form" action="/form-handler" method="post" novalidate>
+                    <div class="govuk-form-group">
+                        <fieldset class="govuk-fieldset">
+                            <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+                                Do you want to accept analytics cookies?
+                            </legend>
+                            <div class="govuk-radios" data-module="govuk-radios">
+                                <div class="govuk-radios__item">
+                                    <input class="govuk-radios__input" id="cookies-analytics-yes" name="cookies[analytics]" type="radio" value="yes">
+                                    <label class="govuk-label govuk-radios__label" for="cookies-analytics-yes">
+                                        Yes
+                                    </label>
+                                </div>
+                                <div class="govuk-radios__item">
+                                    <input class="govuk-radios__input" id="cookies-analytics-no" name="cookies[analytics]" type="radio" value="no" checked>
+                                    <label class="govuk-label govuk-radios__label" for="cookies-analytics-no">
+                                        No
+                                    </label>
+                                </div>
                             </div>
-                            <div class="govuk-radios__item">
-                                <input class="govuk-radios__input" id="cookies-analytics-no" name="cookies[analytics]" type="radio" value="no" checked>
-                                <label class="govuk-label govuk-radios__label" for="cookies-analytics-no">
-                                    No
-                                </label>
-                            </div>
-                        </div>
-                    </fieldset>
-                </div>
-                <button type="submit" class="govuk-button" data-module="govuk-button">
-                    Save cookie settings
-                </button>
-            </form>
+                        </fieldset>
+                    </div>
+                    <button type="submit" class="govuk-button" data-module="govuk-button">
+                        Save cookie settings
+                    </button>
+                </form>
+            </div>
         </div>
     </div>
 </div>

--- a/CheckChildcareEligibility.Admin/Views/WorkingFamiliesCheck/Outcome/Not_Found_WF.cshtml
+++ b/CheckChildcareEligibility.Admin/Views/WorkingFamiliesCheck/Outcome/Not_Found_WF.cshtml
@@ -7,7 +7,7 @@
 <div class="govuk-grid-column-full">
     <a class="govuk-back-link-nolink"></a>
 
-    <div id="content" data-type="Not_Found" class="govuk-grid-row">
+    <div data-type="Not_Found" class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title"
                  data-module="govuk-notification-banner">
@@ -59,10 +59,8 @@
             <h1 class="govuk-heading-l">What to do next</h1>
             <p class="govuk-body">Check that you entered the parent or guardian last name in full and that all other details are correct.</p>
             <p class="govuk-body">If this keeps happening, <a href="#" id="print-link">print this page</a> for the parent or guardian to check their details.</p>
-            <p class="govuk-body">@Html.ActionLink("Try again", "Enter_Details_WF", "WorkingFamiliesCheck", new { clearData = true }, new { @class = "govuk-button" })</p> <!--change the method that is called here when Jenna has updated-->
-
+            <p class="govuk-body">@Html.ActionLink("Try again", "Enter_Details_WF", "WorkingFamiliesCheck", new { clearData = true }, new { @class = "govuk-button" })</p>
         </div>
-
     </div>
 </div>
 

--- a/CheckChildcareEligibility.Admin/Views/WorkingFamiliesCheck/Outcome/Response_WF.cshtml
+++ b/CheckChildcareEligibility.Admin/Views/WorkingFamiliesCheck/Outcome/Response_WF.cshtml
@@ -8,7 +8,7 @@
     <a class="govuk-back-link-nolink"></a>
 
     <div id="content" data-type="Response" class="govuk-width-container">
-        <main class="govuk-main-wrapper" id="main-content">
+        <div class="govuk-main-wrapper">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-two-thirds">
                     <partial name="_CheckResponseBannerPartial" model="Model" />
@@ -19,6 +19,6 @@
                     <p>View @Html.ActionLink("guidance for childcare for working families", "WF_Guidance", "WorkingFamiliesCheck")</p>
                 </div>
             </div>
-        </main>
+        </div>
     </div>
 </div>


### PR DESCRIPTION
- Align Cookies Consent option with page content.
- Ensure only one 'main' landmark exists per page.

[https://dfedigital.atlassian.net/browse/ELIG-2879](https://dfedigital.atlassian.net/browse/ELIG-2879)