### PR TITLE
ELIG-3032: Add X-Robots-Tag support to disable search indexing

### DIFF
--- a/CheckChildcareEligibility.Admin/Program.cs
+++ b/CheckChildcareEligibility.Admin/Program.cs
@@ -91,7 +91,11 @@ app.Use((context, next) =>
     context.Response.Headers["X-Frame-Options"] = "sameorigin";
     context.Response.Headers["Cache-Control"] = "Private";
     context.Response.Headers["X-XSS-Protection"] = "1; mode=block";
-    context.Response.Headers["X-Content-Type-Options"] = "nosniff";
+    context.Response.Headers["X-Content-Type-Options"] = "nosniff"; 
+    if (!builder.Configuration.GetValue<bool>("AllowSearchIndexing"))
+    {
+        context.Response.Headers["X-Robots-Tag"] = "none";
+    }
     return next.Invoke();
 });
 app.UseSession();

--- a/CheckChildcareEligibility.Admin/appsettings.json
+++ b/CheckChildcareEligibility.Admin/appsettings.json
@@ -14,6 +14,7 @@
     }
   },
   "AllowedHosts": "*",
+  "AllowSearchIndexing": false,
   "Api": {
     "Host": "",
     "AuthorisationUsername": "",


### PR DESCRIPTION
Added X-Robots-Tag to response headers when app setting "AllowSearchIndexing" = "false"