### PR TITLE
Elig 2466 childcare content fixes including wrong eligibility type

### DIFF
--- a/CheckChildcareEligibility.Admin/Gateways/Interfaces/IMenuProvider.cs
+++ b/CheckChildcareEligibility.Admin/Gateways/Interfaces/IMenuProvider.cs
@@ -44,7 +44,7 @@ public class MenuProvider : IMenuProvider
                         ),
                     new MenuItem(
                         "Run a check",
-                        "Run a check for one parent or guardian",
+                        "Run a check",
                         "Run an eligibility check for one parent or guardian.",
                         "Home",
                         "MenuSingleCheck"

--- a/CheckChildcareEligibility.Admin/Views/BulkCheck/DisplayTemplates/BulkCheckStatusViewModel.cshtml
+++ b/CheckChildcareEligibility.Admin/Views/BulkCheck/DisplayTemplates/BulkCheckStatusViewModel.cshtml
@@ -1,4 +1,6 @@
-﻿@model CheckChildcareEligibility.Admin.ViewModels.BulkCheckStatusViewModel
+﻿@using CheckChildcareEligibility.Admin.Domain.Constants.EligibilityTypeConstants
+
+@model CheckChildcareEligibility.Admin.ViewModels.BulkCheckStatusViewModel
 @{
     Dictionary<string, string> statusColor = new()
     {
@@ -14,11 +16,11 @@
         { "Completed", "Complete" },
     };
 
-    Dictionary<string, string> eligibilityTypeName = new()
+    Dictionary<string, string> eligibilityTypeKeyMap = new()
     {
-        { "TwoYearOffer", "2 years old early learning" },
-        { "EarlyYearPupilPremium", "Early years pupil premium" },
-        { "WorkingFamilies", "Childcare for working families" }
+        { "TwoYearOffer", "2YO" },
+        { "EarlyYearPupilPremium", "EYPP" },
+        { "WorkingFamilies", "WF" }
     };
 
     var dateCultureFormatted = TimeZoneInfo.ConvertTimeFromUtc(Model.DateSubmitted, TimeZoneInfo.FindSystemTimeZoneById("GMT Standard Time"));
@@ -27,7 +29,7 @@
 
 <tr>
     <td class="govuk-table__cell">@(Model.Filename)</td>
-    <td class="govuk-table__cell">@(@eligibilityTypeName[Model.EligibilityType])</td>
+    <td class="govuk-table__cell">@(@EligibilityTypeConstants.Labels[eligibilityTypeKeyMap[Model.EligibilityType]])</td>
     <td class="govuk-table__cell">@(dateSubmittedFormatted)</td>
     <td class="govuk-table__cell">@(Model.SubmittedBy)</td>
     <td class="govuk-table__cell">
@@ -46,16 +48,16 @@
                 new { bulkCheckId = Model.BulkCheckId, eligibilityType = Model.EligibilityType },
                 new { @class = "govuk-link", aria_label = "Download results submitted on " + dateSubmittedFormatted }
                 )
-        |
-        @Html.ActionLink(
-                "Delete",
-                "Bulk_check_file_delete",
-                "BulkCheck",
-                new { bulkCheckId = Model.BulkCheckId },
-                new { @class = "govuk-link", aria_label = "Delete results submitted on " + dateSubmittedFormatted }
-                )
-    </td>
-        }
+            |
+            @Html.ActionLink(
+                    "Delete",
+                    "Bulk_check_file_delete",
+                    "BulkCheck",
+                    new { bulkCheckId = Model.BulkCheckId },
+                    new { @class = "govuk-link", aria_label = "Delete results submitted on " + dateSubmittedFormatted }
+                    )
+        </td>
+    }
     else
     {
         <td class="govuk-table__cell"></td>

--- a/CheckChildcareEligibility.Admin/Views/Check/Guidance/Eypp_Guidance.cshtml
+++ b/CheckChildcareEligibility.Admin/Views/Check/Guidance/Eypp_Guidance.cshtml
@@ -24,7 +24,7 @@
             <div id="accordion-default-content-1" class="govuk-accordion__section-content"
                  aria-labelledby="accordion-default-heading-1">
                 <p class="govuk-body">
-                    To see if a parent or guardian can claim early learning for 2-year-olds, you must find their <strong>take-home pay</strong> 
+                    To see if a parent or guardian can claim early years pupil premium, you must find their <strong>take-home pay</strong>
                 </p>
                 <p>
                     <strong>Important:</strong> Any statements provided must show the parent/guardian’s income, and the income of any partner listed on the claim, and the date it was sent.
@@ -50,7 +50,7 @@
             <div class="govuk-accordion__section-header">
                 <h2 class="govuk-accordion__section-heading">
                     <span class="govuk-accordion__section-button" id="accordion-default-heading-2">
-                        Support under part VI of the Immigration and Aslyum Act 1999
+                    Support under part VI of the Immigration and Asylum Act 1999
                     </span>
                 </h2>
             </div>

--- a/CheckChildcareEligibility.Admin/Views/Home/MenuBulkCheck.cshtml
+++ b/CheckChildcareEligibility.Admin/Views/Home/MenuBulkCheck.cshtml
@@ -4,10 +4,21 @@
 
 @{
 	ViewData["Title"] = "Run a batch check";
+    
+	var allowedLASection = Configuration.GetSection("FeatureFlags:LAsThatCanUseWF");
 
-	var allowedLAs = Configuration
-	.GetSection("FeatureFlags:LAsThatCanUseWF")
-	.Get<string[]>() ?? Array.Empty<string>();
+	var allowedLAs = allowedLASection.Get<string[]>() ?? Array.Empty<string>();
+
+	if (!allowedLAs.Any())
+	{
+		var allowedLASetting = allowedLASection.Get<string>();
+
+		allowedLAs = string.IsNullOrWhiteSpace(allowedLASetting)
+			? Array.Empty<string>()
+			: allowedLASetting.Split(',').Select(x => x.Trim()).ToArray();
+	}
+
+	var canUseWorkingFamilies = allowedLAs.Contains(Model.Organisation.EstablishmentNumber?.Trim());
 }
 
 <div class="govuk-grid-column-full">
@@ -57,7 +68,7 @@
 					</div>
 				</div>
 
-				@if (allowedLAs.Contains(Model.Organisation.EstablishmentNumber))
+				@if (canUseWorkingFamilies)
 				{
 					<div class="dfe-card">
 						<div class="dfe-card-container">

--- a/CheckChildcareEligibility.Admin/Views/Home/MenuBulkCheck.cshtml
+++ b/CheckChildcareEligibility.Admin/Views/Home/MenuBulkCheck.cshtml
@@ -5,8 +5,9 @@
 @{
 	ViewData["Title"] = "Run a batch check";
 
-	var allowedLASetting = Configuration.GetSection("FeatureFlags:LAsThatCanUseWF").Get<string>();
-	var allowedLAs = allowedLASetting != null ? allowedLASetting.Split(',').Select(x => x.Trim()).ToArray() : Array.Empty<string>();
+	var allowedLAs = Configuration
+	.GetSection("FeatureFlags:LAsThatCanUseWF")
+	.Get<string[]>() ?? Array.Empty<string>();
 }
 
 <div class="govuk-grid-column-full">
@@ -56,7 +57,7 @@
 					</div>
 				</div>
 
-				@if (allowedLAs.Contains(Model.Organisation.EstablishmentNumber.ToLower()) || allowedLAs.Length == 0)
+				@if (allowedLAs.Contains(Model.Organisation.EstablishmentNumber))
 				{
 					<div class="dfe-card">
 						<div class="dfe-card-container">

--- a/CheckChildcareEligibility.Admin/Views/Home/MenuSingleCheck.cshtml
+++ b/CheckChildcareEligibility.Admin/Views/Home/MenuSingleCheck.cshtml
@@ -5,8 +5,9 @@
 @{
     ViewData["Title"] = "Run a check for one parent or guardian";
     
-    var allowedLASetting = Configuration.GetSection("FeatureFlags:LAsThatCanUseWF").Get<string>();
-    var allowedLAs = allowedLASetting != null ? allowedLASetting.Split(',').Select(x => x.Trim()).ToArray() : Array.Empty<string>();
+    var allowedLAs = Configuration
+    .GetSection("FeatureFlags:LAsThatCanUseWF")
+    .Get<string[]>() ?? Array.Empty<string>();
 }
 
 <div class="govuk-grid-column-full">
@@ -26,7 +27,7 @@
 
             <div class="dfe-grid-container">
 
-                @if (allowedLAs.Contains(Model.Organisation.EstablishmentNumber.ToLower())||allowedLAs.Length==0)
+                @if (allowedLAs.Contains(Model.Organisation.EstablishmentNumber))
                 {
                     <div class="dfe-card">
                         <div class="dfe-card-container">

--- a/CheckChildcareEligibility.Admin/Views/Home/MenuSingleCheck.cshtml
+++ b/CheckChildcareEligibility.Admin/Views/Home/MenuSingleCheck.cshtml
@@ -5,9 +5,20 @@
 @{
     ViewData["Title"] = "Run a check for one parent or guardian";
     
-    var allowedLAs = Configuration
-    .GetSection("FeatureFlags:LAsThatCanUseWF")
-    .Get<string[]>() ?? Array.Empty<string>();
+    var allowedLASection = Configuration.GetSection("FeatureFlags:LAsThatCanUseWF");
+
+    var allowedLAs = allowedLASection.Get<string[]>() ?? Array.Empty<string>();
+
+    if (!allowedLAs.Any())
+    {
+        var allowedLASetting = allowedLASection.Get<string>();
+
+        allowedLAs = string.IsNullOrWhiteSpace(allowedLASetting)
+            ? Array.Empty<string>()
+            : allowedLASetting.Split(',').Select(x => x.Trim()).ToArray();
+    }
+
+    var canUseWorkingFamilies = allowedLAs.Contains(Model.Organisation.EstablishmentNumber?.Trim());
 }
 
 <div class="govuk-grid-column-full">
@@ -27,7 +38,7 @@
 
             <div class="dfe-grid-container">
 
-                @if (allowedLAs.Contains(Model.Organisation.EstablishmentNumber))
+                @if (canUseWorkingFamilies)
                 {
                     <div class="dfe-card">
                         <div class="dfe-card-container">

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -2,14 +2,23 @@ import 'cypress-file-upload';
 
 Cypress.Commands.add('checkSession', (userType: string) => {
   // Check if a logged in session exists and re-use that, else log in
-  const filePath = userType === 'school' ? 'cypress/fixtures/SchoolUserCookies1.json' : userType === 'manchesterLA' ? 'cypress/fixtures/ManchesterLAUserCookies1.json' : 'cypress/fixtures/LAUserCookies1.json';
+  const filePath = userType === 'school'
+    ? 'cypress/fixtures/SchoolUserCookies.json'
+    : userType === 'manchesterLA'
+      ? 'cypress/fixtures/ManchesterLAUserCookies.json'
+      : 'cypress/fixtures/LAUserCookies.json';
   cy.task<Cypress.CookieData | null>('readFileMaybe', filePath).then((data) => {
     if (data && data.cookies) {
       if (data.cookies.length > 0) {
         cy.loadCookies(userType);
         cy.visit((Cypress.config().baseUrl ?? "") + "/home")
 
-        const expectedText = userType === 'school' ? 'The Telford Park School' : userType === 'manchesterLA' ? 'Manchester City Council' : 'Telford and Wrekin Council';
+        const expectedText =
+          userType === 'school'
+            ? 'The Telford Park School'
+            : userType === 'manchesterLA'
+              ? 'Manchester City Council'
+              : 'Telford And Wrekin Council';
         cy.get('.govuk-caption-l').should('include.text', expectedText);
       } else {
         cy.log('No cookies found, forcing new login');
@@ -44,7 +53,7 @@ Cypress.Commands.add('login', (userType) => {
     } else {
       cy.loginLocalAuthorityUser();
     }
-    // cy.storeCookies(userType);
+    cy.storeCookies(userType);
   });
 });
 
@@ -125,8 +134,8 @@ Cypress.Commands.add('loadCookies', (userType: string) => {
   cy.readFile(filePath).then((data: Cypress.CookieData) => {
     if (data && data.cookies) {
       const currentTime = Date.now();
-      const twoHoursInMillis = 60 * 60 * 1000; //Changed from 2 hours to 1 hour. Actual invalidation time unknown.
-      if (currentTime - data.timestamp < twoHoursInMillis) {
+      const oneHourInMillis = 60 * 60 * 1000; //Changed from 2 hours to 1 hour. Actual invalidation time unknown.
+      if (currentTime - data.timestamp < oneHourInMillis) {
         data.cookies.forEach((cookie: Cypress.Cookie) => {
           cy.setCookie(cookie.name, cookie.value, {
             domain: cookie.domain,


### PR DESCRIPTION
Implemented content updates for ELIG-2466. While testing, also fixed an inconsistency where the Working Families tile was shown on menu pages even when disabled via feature flags.