### PR TITLE
Second PR for ELIG-2468 to address an additional pagination rendering issue identified during QA.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -413,3 +413,4 @@ FodyWeavers.xsd
 /tests/cypress/fixtures/*.json
 /CheckChildcareEligibility.Admin/CheckChildcareEligibility.Admin.sln
 /tests/audit.txt
+/tests/run-cypress.ps1

--- a/CheckChildcareEligibility.Admin/Views/BulkCheck/PaginationPartial.cshtml
+++ b/CheckChildcareEligibility.Admin/Views/BulkCheck/PaginationPartial.cshtml
@@ -5,8 +5,8 @@
     {
         <div class="govuk-pagination__prev">
             <a class="govuk-link govuk-pagination__link"
-               href="@Url.Action("Bulk_Check_Status", Model.ControllerName, new { pageNumber = Model.CurrentPage - 1, Model.Keyword, Model.Status })@(Model.DateFrom == null ? "" : $"&DateRange.DateFrom={Model.DateFrom}")"
-               rel="prev">
+                   href="@Url.Action("Bulk_Check_Status", Model.ControllerName, new { pageNumber = Model.CurrentPage - 1, Model.Keyword, Model.Status })@(Model.DateFrom == null ? "" : $"&DateRange.DateFrom={Model.DateFrom}")"
+                   rel="prev">
                 <svg class="govuk-pagination__icon govuk-pagination__icon--prev" xmlns="http://www.w3.org/2000/svg"
                      height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
                     <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
@@ -42,23 +42,25 @@
         {
             <li class="govuk-pagination__item govuk-pagination__item--ellipses">&ctdot;</li>
         }
-        @if (Model.CurrentPage != Model.TotalPages || Model.TotalPages < Model.CurrentPage)
+        @if (Model.TotalPages > 1)
         {
             <li class="govuk-pagination__item @(Model.CurrentPage == Model.TotalPages ? "govuk-pagination__item--current" : "")">
                 <a class="govuk-link govuk-pagination__link"
-               href="@Url.Action("Bulk_Check_Status", Model.ControllerName, new { pageNumber = Model.TotalPages, Model.Keyword, Model.Status })@(Model.DateFrom == null ? "" : $"&DateRange.DateFrom={Model.DateFrom}")"
-               aria-label="Page @Model.TotalPages"
-            @(Model.CurrentPage == Model.TotalPages ? "aria-current=\"page\"" : "")>@Model.TotalPages</a>
-        </li>
+                       href="@Url.Action("Bulk_Check_Status", Model.ControllerName, new { pageNumber = Model.TotalPages, Model.Keyword, Model.Status })@(Model.DateFrom == null ? "" : $"&DateRange.DateFrom={Model.DateFrom}")"
+                       aria-label="Page @Model.TotalPages"
+                    @(Model.CurrentPage == Model.TotalPages ? "aria-current=\"page\"" : "")>
+                    @Model.TotalPages
+                </a>
+            </li>
         }
     </ul>
 
     @if (Model.CurrentPage < Model.TotalPages)
     {
         <div class="govuk-pagination__next">
-			<a class="govuk-link govuk-pagination__link" "Bulk_Check_Status" ,
-			   href="@Url.Action("Bulk_Check_Status", Model.ControllerName, new { pageNumber = Model.CurrentPage + 1, Model.Keyword, Model.Status })@(Model.DateFrom == null ? "" : $"&DateRange.DateFrom={Model.DateFrom}")"
-               rel="next">
+            <a class="govuk-link govuk-pagination__link"
+                   href="@Url.Action("Bulk_Check_Status", Model.ControllerName, new { pageNumber = Model.CurrentPage + 1, Model.Keyword, Model.Status })@(Model.DateFrom == null ? "" : $"&DateRange.DateFrom={Model.DateFrom}")"
+                   rel="next">
                 <span class="govuk-pagination__link-title">
                     Next<span class="govuk-visually-hidden"> page</span>
                 </span>


### PR DESCRIPTION
Changes made:

* Fixed pagination rendering for 2-page result sets.
* Ensured the current page number is always displayed and highlighted in line with GOV.UK guidance.
* Resolved duplicate/missing page number behaviour between page 1 and page 2.
* Removed stray invalid markup from the Next pagination link.

Verified behaviour:

* Page 1 displays: `1 2 Next`
* Page 2 displays: `Previous 1 2`
* Current page is highlighted correctly.
