### PR TITLE
2467+ :Warning not visible, but heard

### DIFF
--- a/CheckChildcareEligibility.Admin/Views/BulkCheck/Bulk_check_file_delete.cshtml
+++ b/CheckChildcareEligibility.Admin/Views/BulkCheck/Bulk_check_file_delete.cshtml
@@ -12,7 +12,7 @@
     <div class="govuk-warning-text">
         <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
         <strong class="govuk-warning-text__text">
-            <span class="govuk-warning-text__assistive">Warning</span>
+            <span class="govuk-visually-hidden">Warning</span>
             You will no longer be able to view or download results.
         </strong>
     </div>


### PR DESCRIPTION
Updated delete confirmation warning markup to use GOV.UK visually hidden accessibility text.

This resolves an issue where the assistive “Warning” text was rendering visibly on the page instead of being announced only to screen readers.
