### PR TITLE
Elig 3159 special characters in NiNo throws an error

### DIFF
--- a/CheckChildcareEligibility.Admin/Views/Check/Enter_Details.cshtml
+++ b/CheckChildcareEligibility.Admin/Views/Check/Enter_Details.cshtml
@@ -2,6 +2,13 @@
 
 @{
     ViewData["Title"] = "Run a check for one parent or guardian";
+
+    var ninoInputClasses = "govuk-input govuk-!-width-one-third js-nino-input";
+
+    if (ViewData.ModelState["NationalInsuranceNumber"]?.Errors.Count > 0)
+    {
+        ninoInputClasses += " govuk-input--error";
+    }
 }
 
 <div class="govuk-grid-column-two-thirds">
@@ -88,9 +95,13 @@
                 <p class="govuk-error-message">
                     <span asp-validation-for="NationalInsuranceNumber"></span>
                 </p>
-                <input class="govuk-input govuk-!-width-one-third @(ViewData.ModelState["NationalInsuranceNumber"]?.Errors.Count > 0 ? "govuk-input--error" : "")"
-                       asp-controller="Check" asp-for="NationalInsuranceNumber" type="text"
-                       spellcheck="false" autocomplete="text">
+                <input class="@ninoInputClasses"
+                       asp-controller="Check"
+                       asp-for="NationalInsuranceNumber"
+                       type="text"
+                       spellcheck="false"
+                       autocomplete="text"
+                       maxlength="9">
             </div>
         </fieldset>
 

--- a/CheckChildcareEligibility.Admin/Views/WorkingFamiliesCheck/Enter_Details_WF.cshtml
+++ b/CheckChildcareEligibility.Admin/Views/WorkingFamiliesCheck/Enter_Details_WF.cshtml
@@ -2,6 +2,13 @@
 
 @{
     ViewData["Title"] = "Enter the eligibility code details";
+
+    var ninoInputClasses = "govuk-input govuk-!-width-one-third js-nino-input";
+
+    if (ViewData.ModelState["NationalInsuranceNumber"]?.Errors.Count > 0)
+    {
+        ninoInputClasses += " govuk-input--error";
+    }
 }
 
 <div class="govuk-grid-column-two-thirds">
@@ -44,9 +51,13 @@
                 <p class="govuk-error-message">
                     <span asp-validation-for="NationalInsuranceNumber"></span>
                 </p>
-                <input class="govuk-input govuk-!-width-one-third @(ViewData.ModelState["NationalInsuranceNumber"]?.Errors.Count > 0 ? "govuk-input--error" : "")"
-                       asp-controller="Check" asp-for="NationalInsuranceNumber" type="text"
-                       spellcheck="false" autocomplete="text">
+                <input class="@ninoInputClasses"
+                       asp-controller="Check"
+                       asp-for="NationalInsuranceNumber"
+                       type="text"
+                       spellcheck="false"
+                       autocomplete="text"
+                       maxlength="9">
             </div>
 
             <div class="govuk-form-group" data-type="dob-form-group">

--- a/CheckChildcareEligibility.Admin/wwwroot/js/site.js
+++ b/CheckChildcareEligibility.Admin/wwwroot/js/site.js
@@ -27,3 +27,18 @@ document.addEventListener("DOMContentLoaded", function () {
     }
 });
 //END-- Back link in views
+
+//BEGIN-- Restrict National Insurance number inputs to alphanumeric characters only
+document.addEventListener("DOMContentLoaded", function () {
+    const ninoInputs = document.querySelectorAll(".js-nino-input");
+
+    ninoInputs.forEach(input => {
+        input.addEventListener("input", function () {
+            this.value = this.value
+                .replace(/[^a-zA-Z0-9]/g, "")
+                .toUpperCase()
+                .slice(0, 9);
+        });
+    });
+});
+//END-- Restrict National Insurance number inputs to alphanumeric characters only

--- a/tests/cypress/e2e/Admin/AdminContentValidation.spec.ts
+++ b/tests/cypress/e2e/Admin/AdminContentValidation.spec.ts
@@ -1,7 +1,7 @@
 const parentLastName = /* Cypress.env('lastName') || */ 'Tester';
 const NIN = 'PN668767B';
 const validNIN = 'NN123456C';
-const invalidNIN = 'INVALID123';
+const invalidNIN = 'QQ123456Z';
 
 const visitPrefilledForm = (onlyfill?: boolean) => {
     if (!onlyfill) {
@@ -267,7 +267,7 @@ describe('National Insurance Number Validation Tests', () => {
 
         // Check that the validation error appears
         cy.get('.govuk-error-summary').should('exist');
-        cy.get('.govuk-error-message').should('contain', 'National Insurance number should contain no more than 9 alphanumeric characters');
+        cy.get('.govuk-error-message').should('contain', 'Enter a National Insurance number in the correct format');
         cy.get('#NationalInsuranceNumber').should('have.class', 'govuk-input--error');
     });
 


### PR DESCRIPTION
Added client-side handling to NINo fields across FSM Admin and Childcare Admin so special characters are removed when entered or pasted. NINo input is also capped at 9 characters and normalised to uppercase.

Existing server-side validation remains unchanged, so with JavaScript disabled, invalid NINos still show the existing validation message:

Enter a National Insurance number in the correct format