### PR TITLE
ELIG-2927 Update GPED display for unavailable Working Families codes

### DIFF
--- a/CheckChildcareEligibility.Admin.Tests/ViewModels/WorkingFamiliesResponseViewModelTests.cs
+++ b/CheckChildcareEligibility.Admin.Tests/ViewModels/WorkingFamiliesResponseViewModelTests.cs
@@ -1,0 +1,110 @@
+﻿using CheckChildcareEligibility.Admin.Boundary.Responses;
+using CheckChildcareEligibility.Admin.ViewModels;
+using FluentAssertions;
+
+namespace CheckChildcareEligibility.Admin.Tests.ViewModels
+{
+    [TestFixture]
+    public class WorkingFamiliesResponseViewModelTests
+    {
+        [Test]
+        public void GracePeriodEndDisplay_WhenChildIsTooYoung_ShouldReturnPlaceholder()
+        {
+            // Arrange
+            var currentTermStart = WorkingFamiliesResponseViewModel.GetTermStart(DateTime.Now);
+            var childDateOfBirth = currentTermStart.AddMonths(-1);
+            var validityStartDate = currentTermStart.AddDays(-1);
+            var sut = CreateViewModel(childDateOfBirth, validityStartDate);
+
+            // Act
+            var result = sut.GracePeriodEndDisplay;
+
+            // Assert
+            sut.ChildIsTooYoung.Should().BeTrue();
+            sut.IsNotValidYet.Should().BeFalse();
+            result.Should().Be("Date will appear here when the code can be used");
+        }
+
+        [Test]
+        public void GracePeriodEndDisplay_WhenCodeIsNotValidYet_ShouldReturnPlaceholder()
+        {
+            // Arrange
+            var currentTermStart = WorkingFamiliesResponseViewModel.GetTermStart(DateTime.Now);
+            var childDateOfBirth = currentTermStart.AddYears(-3);
+            var validityStartDate = currentTermStart;
+            var sut = CreateViewModel(childDateOfBirth, validityStartDate);
+
+            // Act
+            var result = sut.GracePeriodEndDisplay;
+
+            // Assert
+            sut.ChildIsTooYoung.Should().BeFalse();
+            sut.IsNotValidYet.Should().BeTrue();
+            result.Should().Be("Date will appear here when the code can be used");
+        }
+
+        [Test]
+        public void GracePeriodEndDisplay_WhenCodeIsValid_ShouldReturnFormattedGracePeriodEndDate()
+        {
+            // Arrange
+            var currentTermStart = WorkingFamiliesResponseViewModel.GetTermStart(DateTime.Now);
+            var childDateOfBirth = currentTermStart.AddYears(-3);
+            var validityStartDate = currentTermStart.AddDays(-1);
+            var gracePeriodEndDate = DateTime.Today.AddMonths(6);
+            var sut = CreateViewModel(
+                childDateOfBirth,
+                validityStartDate,
+                gracePeriodEndDate);
+
+            // Act
+            var result = sut.GracePeriodEndDisplay;
+
+            // Assert
+            sut.ChildIsTooYoung.Should().BeFalse();
+            sut.IsNotValidYet.Should().BeFalse();
+            result.Should().Be(gracePeriodEndDate.ToString("d MMMM yyyy"));
+        }
+
+        [Test]
+        public void GracePeriodEndDisplay_WhenChildIsTooOld_ShouldReturnFormattedGracePeriodEndDate()
+        {
+            // Arrange
+            var currentTermStart = WorkingFamiliesResponseViewModel.GetTermStart(DateTime.Now);
+            var childDateOfBirth = currentTermStart.AddYears(-6);
+            var validityStartDate = currentTermStart.AddDays(-1);
+            var gracePeriodEndDate = DateTime.Today.AddMonths(6);
+            var sut = CreateViewModel(
+                childDateOfBirth,
+                validityStartDate,
+                gracePeriodEndDate);
+
+            // Act
+            var result = sut.GracePeriodEndDisplay;
+
+            // Assert
+            sut.ChildIsTooOld.Should().BeTrue();
+            result.Should().Be(gracePeriodEndDate.ToString("d MMMM yyyy"));
+        }
+
+        private static WorkingFamiliesResponseViewModel CreateViewModel(
+            DateTime childDateOfBirth,
+            DateTime validityStartDate,
+            DateTime? gracePeriodEndDate = null)
+        {
+            return new WorkingFamiliesResponseViewModel
+            {
+                Response = new CheckEligibilityItemWorkingFamilies
+                {
+                    NationalInsuranceNumber = "QQ123456C",
+                    DateOfBirth = childDateOfBirth.ToString("yyyy-MM-dd"),
+                    Status = "eligible",
+                    EligibilityCode = "50000000000",
+                    ValidityStartDate = validityStartDate.ToString("yyyy-MM-dd"),
+                    ValidityEndDate = DateTime.Today.AddMonths(3).ToString("yyyy-MM-dd"),
+                    GracePeriodEndDate = (gracePeriodEndDate ?? DateTime.Today.AddMonths(6))
+                        .ToString("yyyy-MM-dd")
+                }
+            };
+        }
+    }
+}

--- a/CheckChildcareEligibility.Admin/Domain/Constants/Generic/WorkingFamiliesResponseDetails.cs
+++ b/CheckChildcareEligibility.Admin/Domain/Constants/Generic/WorkingFamiliesResponseDetails.cs
@@ -10,6 +10,7 @@ namespace CheckChildcareEligibility.Admin.Domain.Constants.Generic
         public const string StatusDueNow = "Due now";
         public const string StatusOverdue = "Overdue";
         public const string StatusChildTooOld = "Child too old";
+        public const string GracePeriodEndDateNotAvailable = "Date will appear here when the code can be used";
         public static readonly string[] ReconfirmationStatusNotApplicable = {StatusNotApplicable,"grey"};
         public static readonly string[] ReconfirmationStatusNotDueYet = { StatusNotDueYet, "green"};
         public static readonly string[] ReconfirmationStatusDueNow = { StatusDueNow, "yellow"};

--- a/CheckChildcareEligibility.Admin/ViewModels/WorkingFamiliesResponseViewModel.cs
+++ b/CheckChildcareEligibility.Admin/ViewModels/WorkingFamiliesResponseViewModel.cs
@@ -17,6 +17,10 @@ namespace CheckChildcareEligibility.Admin.ViewModels
         public DateTime ValidityStartDate => DateTime.Parse(Response.ValidityStartDate);
         public DateTime ValidityEndDate => DateTime.Parse(Response.ValidityEndDate);
         public DateTime GracePeriodEndDate => DateTime.Parse(Response.GracePeriodEndDate);
+        public string GracePeriodEndDisplay =>
+            (IsEligible && ChildIsTooYoung) || IsNotValidYet
+                ? WorkingFamiliesResponseDetails.GracePeriodEndDateNotAvailable
+                : GracePeriodEndDate.ToString("d MMMM yyyy");
         public DateTime ChildDateOfBirth => DateTime.Parse(Response.DateOfBirth);
         private DateTime StartReconfirmDate => ValidityEndDate.AddDays(-28);
         public int CurrentYear => DateTime.UtcNow.Year;

--- a/CheckChildcareEligibility.Admin/Views/Shared/_CheckResponseDetailsPartial.cshtml
+++ b/CheckChildcareEligibility.Admin/Views/Shared/_CheckResponseDetailsPartial.cshtml
@@ -62,7 +62,7 @@
             Grace period ends
         </dt>
         <dd class="govuk-summary-list__value">
-            @Model.GracePeriodEndDate.ToString("d MMMM yyyy")
+            @Model.GracePeriodEndDisplay
         </dd>
     </div>
     <div class="govuk-summary-list__row">


### PR DESCRIPTION
## Summary

Updates the Childcare Admin single-check outcome to control how the Grace Period End Date is displayed.

- Shows `Date will appear here when the code can be used` when:
  - the child is too young
  - the code cannot be used yet
- Continues to display the GPED returned by the API for other states, including:
  - codes in their grace period
  - children who have reached compulsory school age
- Keeps GPED calculation in the eligibility engine; no API or calculation changes are included.
- Keeps existing VSD, banner and reconfirmation behaviour unchanged.

The display rule is held in `WorkingFamiliesResponseViewModel`, with the details partial rendering the resulting value.

This implements the currently agreed single-check scope. Batch outcome presentation remains outside this change while that scope is under discussion.

## Testing

Automated:

- Added ViewModel tests for:
  - child too young
  - code cannot be used yet
  - valid code
  - child too old
- Full .NET test suite passed: 132/132.
- Application and Razor build passed.

Manual single-check verification using generated test data:

- Child too young: passed; placeholder displayed.
- Code cannot be used yet: passed; placeholder displayed.
- Code in grace period: passed; returned GPED displayed.
- Child too old: passed; returned GPED displayed.

A valid-state record cannot currently be generated through the standard test codes because the current term exceeds the 99-day test-data limit. The valid branch is covered by unit testing, and an additional dev record is being prepared for manual verification.