### PR TITLE
ELIG-3522 Show expired view when child is too old

### DIFF
--- a/CheckChildcareEligibility.Admin.Tests/ViewModels/WorkingFamiliesResponseViewModelTests.cs
+++ b/CheckChildcareEligibility.Admin.Tests/ViewModels/WorkingFamiliesResponseViewModelTests.cs
@@ -1,4 +1,5 @@
 ﻿using CheckChildcareEligibility.Admin.Boundary.Responses;
+using CheckChildcareEligibility.Admin.Domain.Constants.Generic;
 using CheckChildcareEligibility.Admin.ViewModels;
 using FluentAssertions;
 
@@ -66,7 +67,7 @@ namespace CheckChildcareEligibility.Admin.Tests.ViewModels
         }
 
         [Test]
-        public void GracePeriodEndDisplay_WhenChildIsTooOld_ShouldReturnFormattedGracePeriodEndDate()
+        public void GracePeriodEndDisplay_WhenChildIsTooOld_ShouldReturnFormattedValidityEndDate()
         {
             // Arrange
             var currentTermStart = WorkingFamiliesResponseViewModel.GetTermStart(DateTime.Now);
@@ -83,7 +84,53 @@ namespace CheckChildcareEligibility.Admin.Tests.ViewModels
 
             // Assert
             sut.ChildIsTooOld.Should().BeTrue();
-            result.Should().Be(gracePeriodEndDate.ToString("d MMMM yyyy"));
+            result.Should().Be(sut.ValidityEndDate.ToString("d MMMM yyyy"));
+            result.Should().NotBe(gracePeriodEndDate.ToString("d MMMM yyyy"));
+            sut.GracePeriodEndLabel.Should().Be("Grace period ended");
+        }
+
+        [Test]
+        public void SetBannerValues_WhenChildIsTooOldAndCodeIsNotValidYet_ShouldSetExpiredBanner()
+        {
+            // Arrange
+            var currentTermStart = WorkingFamiliesResponseViewModel.GetTermStart(DateTime.Now);
+            var childDateOfBirth = currentTermStart.AddYears(-6);
+            var validityStartDate = currentTermStart.AddDays(1);
+            var sut = CreateViewModel(childDateOfBirth, validityStartDate);
+
+            // Act
+            sut.SetBannerValues();
+
+            // Assert
+            sut.ChildIsTooOld.Should().BeTrue();
+            sut.IsNotValidYet.Should().BeTrue();
+            sut.CodeStatus.Should().Be(WorkingFamiliesResponseBanner.CodeExpired);
+            sut.BannerColour.Should().Be(WorkingFamiliesResponseBanner.ColourOrange);
+            sut.TermValidityDetails.Should().Be(WorkingFamiliesResponseBanner.TermExpiredOn);
+            sut.TermInfo.Should().Be(sut.ValidityEndDate.ToString("d MMMM yyyy"));
+            sut.GracePeriodEndDisplay.Should().Be(sut.ValidityEndDate.ToString("d MMMM yyyy"));
+            sut.GracePeriodEndLabel.Should().Be("Grace period ended");
+        }
+
+        [Test]
+        public void SetBannerValues_WhenChildIsTooYoungAndCodeIsNotValidYet_ShouldSetChildTooYoungBanner()
+        {
+            // Arrange
+            var currentTermStart = WorkingFamiliesResponseViewModel.GetTermStart(DateTime.Now);
+            var childDateOfBirth = currentTermStart.AddMonths(-1);
+            var validityStartDate = currentTermStart.AddDays(1);
+            var sut = CreateViewModel(childDateOfBirth, validityStartDate);
+
+            // Act
+            sut.SetBannerValues();
+
+            // Assert
+            sut.ChildIsTooYoung.Should().BeTrue();
+            sut.IsNotValidYet.Should().BeTrue();
+            sut.CodeStatus.Should().Be(WorkingFamiliesResponseBanner.CodeChildTooYoung);
+            sut.BannerColour.Should().Be(WorkingFamiliesResponseBanner.ColourBlue);
+            sut.TermValidityDetails.Should().Be(WorkingFamiliesResponseBanner.TermValidFrom);
+            sut.GracePeriodEndLabel.Should().Be("Grace period ends");
         }
 
         private static WorkingFamiliesResponseViewModel CreateViewModel(

--- a/CheckChildcareEligibility.Admin/ViewModels/WorkingFamiliesResponseViewModel.cs
+++ b/CheckChildcareEligibility.Admin/ViewModels/WorkingFamiliesResponseViewModel.cs
@@ -18,9 +18,15 @@ namespace CheckChildcareEligibility.Admin.ViewModels
         public DateTime ValidityEndDate => DateTime.Parse(Response.ValidityEndDate);
         public DateTime GracePeriodEndDate => DateTime.Parse(Response.GracePeriodEndDate);
         public string GracePeriodEndDisplay =>
-            (IsEligible && ChildIsTooYoung) || IsNotValidYet
-                ? WorkingFamiliesResponseDetails.GracePeriodEndDateNotAvailable
-                : GracePeriodEndDate.ToString("d MMMM yyyy");
+            ChildIsTooOld
+                ? ValidityEndDate.ToString("d MMMM yyyy")
+                : (IsEligible && ChildIsTooYoung) || IsNotValidYet
+                    ? WorkingFamiliesResponseDetails.GracePeriodEndDateNotAvailable
+                    : GracePeriodEndDate.ToString("d MMMM yyyy");
+        public string GracePeriodEndLabel =>
+            ChildIsTooOld
+                ? "Grace period ended"
+                : "Grace period ends";
         public DateTime ChildDateOfBirth => DateTime.Parse(Response.DateOfBirth);
         private DateTime StartReconfirmDate => ValidityEndDate.AddDays(-28);
         public int CurrentYear => DateTime.UtcNow.Year;
@@ -31,7 +37,10 @@ namespace CheckChildcareEligibility.Admin.ViewModels
 
 
 
-        public string TermInfo => GetTermInfo(ValidityStartDate);
+        public string TermInfo =>
+            ChildIsTooOld
+                ? ValidityEndDate.ToString("d MMMM yyyy")
+                : GetTermInfo(ValidityStartDate);
         public string CurrentTerm => GetTermName(DateTime.Now);
         public string NextTerm => GetTermName(GetNextTerm(GetTermStart(DateTime.Now)));
 
@@ -179,6 +188,12 @@ namespace CheckChildcareEligibility.Admin.ViewModels
                 BannerColour = WorkingFamiliesResponseBanner.ColourBlue;
                 TermValidityDetails = WorkingFamiliesResponseBanner.TermValidFrom;
                 CodeType = string.Empty;
+            }
+            else if (ChildIsTooOld) // Child has reached compulsory school age
+            {
+                CodeStatus = WorkingFamiliesResponseBanner.CodeExpired;
+                BannerColour = WorkingFamiliesResponseBanner.ColourOrange;
+                TermValidityDetails = WorkingFamiliesResponseBanner.TermExpiredOn;
             }
             else if (IsNotValidYet) // Code cannot be used yet
             {

--- a/CheckChildcareEligibility.Admin/Views/Shared/_CheckResponseDetailsPartial.cshtml
+++ b/CheckChildcareEligibility.Admin/Views/Shared/_CheckResponseDetailsPartial.cshtml
@@ -59,7 +59,7 @@
     </div>
     <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
-            Grace period ends
+            @Model.GracePeriodEndLabel
         </dt>
         <dd class="govuk-summary-list__value">
             @Model.GracePeriodEndDisplay


### PR DESCRIPTION
Updates the Working Families single-check outcome so Child too old takes precedence over Code cannot be used yet.

Displays the Code expired banner.
Uses VED for the banner expiry date and grace-period row.
Changes the row label to Grace period ended.
Preserves the existing Child too young outcome.
Adds regression coverage for conflicting age and future-date states.

Verification:

Exact ticket reproduction manually verified.
6/6 Working Families ViewModel tests passed.
Full .NET suite passed: 134/134 tests.