### PR TITLE
ELIG-2986 Display validity end date for temporary codes

### DIFF
--- a/CheckChildcareEligibility.Admin.Tests/ViewModels/WorkingFamiliesResponseViewModelTests.cs
+++ b/CheckChildcareEligibility.Admin.Tests/ViewModels/WorkingFamiliesResponseViewModelTests.cs
@@ -86,10 +86,73 @@ namespace CheckChildcareEligibility.Admin.Tests.ViewModels
             result.Should().Be(gracePeriodEndDate.ToString("d MMMM yyyy"));
         }
 
+        [Test]
+        public void ReconfirmationDetails_WhenTemporaryCode_ShouldShowValidityEndDate()
+        {
+            // Arrange
+            var validityEndDate = DateTime.Today.AddMonths(3);
+            var sut = CreateViewModel(
+                DateTime.Today.AddYears(-3),
+                DateTime.Today.AddMonths(-3),
+                validityEndDate: validityEndDate,
+                eligibilityCode: "10000000000");
+
+            // Act
+            var label = sut.ReconfirmationDateLabel;
+            var value = sut.ReconfirmationDateDisplay;
+
+            // Assert
+            sut.IsTemporaryCode.Should().BeTrue();
+            label.Should().Be("Apply for a new code by");
+            value.Should().Be(validityEndDate.ToString("d MMMM yyyy"));
+        }
+
+        [Test]
+        public void ReconfirmationDetails_WhenPermanentCode_ShouldShowReconfirmationWindow()
+        {
+            // Arrange
+            var validityEndDate = DateTime.Today.AddMonths(3);
+            var sut = CreateViewModel(
+                DateTime.Today.AddYears(-3),
+                DateTime.Today.AddMonths(-3),
+                validityEndDate: validityEndDate);
+
+            // Act
+            var label = sut.ReconfirmationDateLabel;
+            var value = sut.ReconfirmationDateDisplay;
+
+            // Assert
+            sut.IsTemporaryCode.Should().BeFalse();
+            label.Should().Be("Reconfirm between");
+            value.Should().Be(
+                $"{validityEndDate.AddDays(-28):d MMMM yyyy} and {validityEndDate:d MMMM yyyy}");
+        }
+
+        [Test]
+        public void ReconfirmationDetails_WhenChildIsTooOld_ShouldRemainNotApplicable()
+        {
+            // Arrange
+            var currentTermStart = WorkingFamiliesResponseViewModel.GetTermStart(DateTime.Now);
+            var sut = CreateViewModel(
+                currentTermStart.AddYears(-6),
+                currentTermStart.AddDays(-1));
+
+            // Act
+            var label = sut.ReconfirmationDateLabel;
+            var value = sut.ReconfirmationDateDisplay;
+
+            // Assert
+            sut.ChildIsTooOld.Should().BeTrue();
+            label.Should().Be("Reconfirm between");
+            value.Should().Be("Not applicable");
+        }
+
         private static WorkingFamiliesResponseViewModel CreateViewModel(
             DateTime childDateOfBirth,
             DateTime validityStartDate,
-            DateTime? gracePeriodEndDate = null)
+            DateTime? gracePeriodEndDate = null,
+            DateTime? validityEndDate = null,
+            string eligibilityCode = "50000000000")
         {
             return new WorkingFamiliesResponseViewModel
             {
@@ -98,9 +161,10 @@ namespace CheckChildcareEligibility.Admin.Tests.ViewModels
                     NationalInsuranceNumber = "QQ123456C",
                     DateOfBirth = childDateOfBirth.ToString("yyyy-MM-dd"),
                     Status = "eligible",
-                    EligibilityCode = "50000000000",
+                    EligibilityCode = eligibilityCode,
                     ValidityStartDate = validityStartDate.ToString("yyyy-MM-dd"),
-                    ValidityEndDate = DateTime.Today.AddMonths(3).ToString("yyyy-MM-dd"),
+                    ValidityEndDate = (validityEndDate ?? DateTime.Today.AddMonths(3))
+                        .ToString("yyyy-MM-dd"),
                     GracePeriodEndDate = (gracePeriodEndDate ?? DateTime.Today.AddMonths(6))
                         .ToString("yyyy-MM-dd")
                 }

--- a/CheckChildcareEligibility.Admin/ViewModels/WorkingFamiliesResponseViewModel.cs
+++ b/CheckChildcareEligibility.Admin/ViewModels/WorkingFamiliesResponseViewModel.cs
@@ -17,10 +17,34 @@ namespace CheckChildcareEligibility.Admin.ViewModels
         public DateTime ValidityStartDate => DateTime.Parse(Response.ValidityStartDate);
         public DateTime ValidityEndDate => DateTime.Parse(Response.ValidityEndDate);
         public DateTime GracePeriodEndDate => DateTime.Parse(Response.GracePeriodEndDate);
+
         public string GracePeriodEndDisplay =>
             (IsEligible && ChildIsTooYoung) || IsNotValidYet
                 ? WorkingFamiliesResponseDetails.GracePeriodEndDateNotAvailable
                 : GracePeriodEndDate.ToString("d MMMM yyyy");
+        public string ReconfirmationDateLabel =>
+            IsTemporaryCode
+                ? "Apply for a new code by"
+                : "Reconfirm between";
+
+        public string ReconfirmationDateDisplay
+        {
+            get
+            {
+                if (IsTemporaryCode)
+                {
+                    return ValidityEndDate.ToString("d MMMM yyyy");
+                }
+
+                if (ChildIsTooOld)
+                {
+                    return WorkingFamiliesResponseDetails.StatusNotApplicable;
+                }
+
+                return $"{StartReconfirmDate:d MMMM yyyy} and {ValidityEndDate:d MMMM yyyy}";
+            }
+        }
+
         public DateTime ChildDateOfBirth => DateTime.Parse(Response.DateOfBirth);
         private DateTime StartReconfirmDate => ValidityEndDate.AddDays(-28);
         public int CurrentYear => DateTime.UtcNow.Year;

--- a/CheckChildcareEligibility.Admin/Views/Shared/_CheckResponseDetailsPartial.cshtml
+++ b/CheckChildcareEligibility.Admin/Views/Shared/_CheckResponseDetailsPartial.cshtml
@@ -1,15 +1,7 @@
 ﻿@model CheckChildcareEligibility.Admin.ViewModels.WorkingFamiliesResponseViewModel
-@using CheckChildcareEligibility.Admin.Domain.Constants.Generic
 
 @{
-    DateTime startReconfirmDate = Model.ValidityEndDate.AddDays(-28);
-    string reconfirmBetween = $"{startReconfirmDate.ToString("d MMMM yyyy")} and {Model.ValidityEndDate.ToString("d MMMM yyyy")}";
     string[] reconfirmationStatus = Model.GetReconfirmationStatus();
-
-    if (Model.IsTemporaryCode || Model.ChildIsTooOld)
-    {
-        reconfirmBetween = WorkingFamiliesResponseDetails.StatusNotApplicable;
-    }
 }
 
 <h2 class="govuk-heading-m">Details checked</h2>
@@ -51,10 +43,10 @@
     </div>
     <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
-            Reconfirm between
+            @Model.ReconfirmationDateLabel
         </dt>
         <dd class="govuk-summary-list__value">
-            @reconfirmBetween
+            @Model.ReconfirmationDateDisplay
         </dd>
     </div>
     <div class="govuk-summary-list__row">


### PR DESCRIPTION
## Summary

Updates the Working Families single-check outcome page for temporary codes.

Temporary codes now display:

- `Apply for a new code by` instead of `Reconfirm between`
- the validity end date instead of `Not applicable`

The grace period end date remains displayed separately, and the reconfirmation status remains `Not applicable`.

Permanent-code and child-too-old behaviour remain unchanged.

## Testing

- Added view-model tests covering:
  - temporary-code label and validity end date
  - unchanged permanent-code reconfirmation window
  - unchanged child-too-old behaviour
- 148 unit tests passed
- Release build succeeded with 0 warnings and 0 errors
- Manually verified locally using the ticket’s temporary code:
  - `Apply for a new code by`: 3 April 2026
  - `Grace period ends`: 31 August 2026
  - `Reconfirmation status`: Not applicable
  
  
<img width="547" height="505" alt="image" src="https://github.com/user-attachments/assets/86a07be5-51e7-42c2-9f68-545488e08724" />
