### PR TITLE
ELIG-3494 Fix Childcare single-check loader redirect loop

### DIFF
--- a/CheckChildcareEligibility.Admin/Views/Check/Loader.cshtml
+++ b/CheckChildcareEligibility.Admin/Views/Check/Loader.cshtml
@@ -2,10 +2,6 @@
     ViewData["Title"] = "Checking eligibility";
 }
 
-@section Head {
-    <meta http-equiv="refresh" content="0; url='@Url.Action("Loader", "Check")'" />
-}
-
 <div class="govuk-grid-column-full">
     <a class="govuk-back-link-nolink"></a>
 

--- a/CheckChildcareEligibility.Admin/Views/WorkingFamiliesCheck/Loader_WF.cshtml
+++ b/CheckChildcareEligibility.Admin/Views/WorkingFamiliesCheck/Loader_WF.cshtml
@@ -2,10 +2,6 @@
     ViewData["Title"] = "Checking eligibility";
 }
 
-@section Head {
-    <meta http-equiv="refresh" content="0; url='@Url.Action("Loader_WF", "WorkingFamiliesCheck")'" />
-}
-
 <div class="govuk-grid-column-full">
     <a class="govuk-back-link-nolink"></a>
 

--- a/CheckChildcareEligibility.Admin/wwwroot/js/eligibility-loader.js
+++ b/CheckChildcareEligibility.Admin/wwwroot/js/eligibility-loader.js
@@ -1,22 +1,37 @@
 function checkStatus() {
-    let url = document.getElementById("content").getAttribute("data-url");
+    const currentContent = document.getElementById("content");
+    const url = currentContent?.getAttribute("data-url");
+
+    if (!currentContent || !url) {
+        clearInterval(loaderTimer);
+        return;
+    }
+
     fetch(url)
         .then(response => response.text())
         .then(html => {
-            // Parse the fetched HTML and extract the #content section
-            var parser = new DOMParser();
-            var doc = parser.parseFromString(html, 'text/html');
-            var newContent = doc.getElementById("content");
+            const parser = new DOMParser();
+            const doc = parser.parseFromString(html, "text/html");
+            const newContent = doc.getElementById("content");
+            const currentContainer = currentContent.parentElement;
+            const newContainer = newContent?.parentElement;
 
-            // Only update the content if the data-type has changed
-            if (newContent.getAttribute("data-type") !== document.getElementById("content").getAttribute("data-type")) {
-                document.getElementById("content").innerHTML = newContent.innerHTML;
-                document.getElementById("content").setAttribute("data-type", newContent.getAttribute("data-type"));
-                if (!newContent.getAttribute("data-url")) clearInterval(loaderTimer);
+            // Ignore an unexpected response or a poll superseded by another response.
+            if (!newContent || !currentContainer || !newContainer) {
+                return;
+            }
+
+            if (newContent.getAttribute("data-type") !== currentContent.getAttribute("data-type")) {
+                currentContainer.innerHTML = newContainer.innerHTML;
+                document.title = doc.title;
+
+                if (!newContent.getAttribute("data-url")) {
+                    clearInterval(loaderTimer);
+                }
             }
         })
         .catch(error => {
-            console.error('Error fetching status:', error);
+            console.error("Error fetching status:", error);
         });
 }
 


### PR DESCRIPTION
## Summary

Fixes the repeated full-page reloads on Childcare single-check loader pages.

The zero-second meta refresh was causing `/Check/Loader` and `/WorkingFamiliesCheck/Loader_WF` to reload continuously while checks were processing. This restarted the spinner, repeated page announcements for screen readers and caused Cypress to exceed its redirect limit.

## Changes

* Removed the unconditional zero-second meta refresh from the 2YO/EYPP and Working Families loader pages.
* Retained the five-second non-JavaScript fallback.
* Continued polling through background `fetch` requests.
* Updated the outcome content, Back link and browser title when processing completes.
* Added safeguards for unexpected responses and overlapping polling requests.
* Stopped polling once a final outcome is returned.

## Testing

* 147 unit tests passed.
* JavaScript syntax validation passed.
* `git diff --check` passed.
* Manually verified the 2YO Technical Error flow using an `XX` NINO:

  * one initial document request;
  * subsequent status checks used `fetch`;
  * spinner ran continuously;
  * Technical Error outcome displayed;
  * browser title and Back link updated correctly;
  * polling stopped after completion.
* Manually verified equivalent polling behaviour for Working Families.
* Temporarily enabled the Technical Error Cypress test from the ELIG-3368 branch. It reached the Technical Error outcome without the previous redirect-limit failure. Its later assertion remains dependent on the unmerged ELIG-3368 changes.
