### PR TITLE
ELIG-3556 Align Childcare bulk surname validation

### DIFF
--- a/CheckChildcareEligibility.Admin.Tests/Validators/CheckEligibilityRequestDataValidatorNameTests.cs
+++ b/CheckChildcareEligibility.Admin.Tests/Validators/CheckEligibilityRequestDataValidatorNameTests.cs
@@ -1,0 +1,91 @@
+﻿using CheckChildcareEligibility.Admin.Boundary.Requests;
+using CheckChildcareEligibility.Admin.Domain.Constants.ErrorMessages;
+using CheckChildcareEligibility.Admin.Domain.Enums;
+using CheckChildcareEligibility.Admin.Domain.Validation;
+using FluentAssertions;
+using FluentValidation;
+
+namespace CheckChildcareEligibility.Admin.Tests.Validators;
+
+[TestFixture]
+public class CheckEligibilityRequestDataValidatorNameTests
+{
+    private IValidator<IEligibilityServiceType> _sut = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _sut = new CheckEligibilityRequestDataValidator();
+    }
+
+    [TestCase("García")]
+    [TestCase("O'Connor")]
+    [TestCase("O\u2019Connor")]
+    [TestCase("Smith-Jones")]
+    public void Validate_EyppSupportedLastName_Passes(string lastName)
+    {
+        var request = CreateValidRequest(
+            CheckEligibilityType.EarlyYearPupilPremium,
+            lastName);
+
+        var result = _sut.Validate(request);
+
+        result.Errors.Should().BeEmpty();
+    }
+
+    [Test]
+    public void Validate_TwoYearOfferAccentedLastName_Passes()
+    {
+        var request = CreateValidRequest(
+            CheckEligibilityType.TwoYearOffer,
+            "García");
+
+        var result = _sut.Validate(request);
+
+        result.Errors.Should().BeEmpty();
+    }
+
+    [TestCase(CheckEligibilityType.EarlyYearPupilPremium)]
+    [TestCase(CheckEligibilityType.TwoYearOffer)]
+    public void Validate_UnsupportedLastName_ReturnsInvalidCharacterMessage(
+        CheckEligibilityType eligibilityType)
+    {
+        var request = CreateValidRequest(eligibilityType, "Smith@");
+
+        var result = _sut.Validate(request);
+
+        result.Errors
+            .Select(x => x.ErrorMessage)
+            .Should()
+            .Equal(ValidationMessages.ValidLastName);
+    }
+
+    [TestCase(CheckEligibilityType.EarlyYearPupilPremium)]
+    [TestCase(CheckEligibilityType.TwoYearOffer)]
+    public void Validate_MissingLastName_ReturnsOnlyRequiredMessage(
+        CheckEligibilityType eligibilityType)
+    {
+        var request = CreateValidRequest(eligibilityType, string.Empty);
+
+        var result = _sut.Validate(request);
+
+        result.Errors
+            .Select(x => x.ErrorMessage)
+            .Should()
+            .Equal(ValidationMessages.RequiredLastName);
+    }
+
+    private static CheckEligibilityRequestData CreateValidRequest(
+        CheckEligibilityType eligibilityType,
+        string lastName)
+    {
+        return new CheckEligibilityRequestData
+        {
+            LastName = lastName,
+            DateOfBirth = "1980-01-01",
+            NationalInsuranceNumber = "AB124456A",
+            Type = eligibilityType,
+            Sequence = 1
+        };
+    }
+}

--- a/CheckChildcareEligibility.Admin/Domain/Constants/ErrorMessages/CheckDataValidationMessages.cs
+++ b/CheckChildcareEligibility.Admin/Domain/Constants/ErrorMessages/CheckDataValidationMessages.cs
@@ -5,7 +5,7 @@ public static class ValidationMessages
     public const string RequiredLastName = "Enter parent or guardian's last name";
     public const string RequiredDOB = "Enter parent or guardian's date of birth";
     public const string RequiredNI = "Enter parent or guardian's National Insurance number";
-    public const string ValidLastName = "Parent or guardian's last name should not contain numbers";
+    public const string ValidLastName = "Parent or guardian's last name contains an invalid character";
     public const string ValidDOB = "The date of birth must be in yyyy-mm-dd or dd-mm-yyyy format";
     public const string ValidNI = "Enter a National Insurance number in the correct format";
     public const string ChildDOB = "Child Date of birth is required:- (yyyy-mm-dd)";

--- a/CheckChildcareEligibility.Admin/Domain/Validation/DataValidation.cs
+++ b/CheckChildcareEligibility.Admin/Domain/Validation/DataValidation.cs
@@ -1,5 +1,5 @@
-﻿using CheckChildcareEligibility.Admin.Domain.Constants.ErrorMessages;
-using System.Text.RegularExpressions;
+﻿using System.Text.RegularExpressions;
+using CheckChildcareEligibility.Admin.Attributes;
 
 namespace CheckYourEligibility.API.Domain.Validation;
 
@@ -7,12 +7,10 @@ internal static class DataValidation
 {
     internal static bool BeAValidName(string? value)
     {
-        if (string.IsNullOrWhiteSpace(value)) return false;
-        var regexString =
-            @"^[^\d]*$";
-        var rg = new Regex(regexString);
-        var res = rg.Match(value);
-        return res.Success;
+        if (string.IsNullOrWhiteSpace(value))
+            return false;
+
+        return Regex.IsMatch(value, NameAttribute.NameValidationRegex);
     }
 
     internal static bool BeAValidDate(string value)


### PR DESCRIPTION
## Summary

* Aligns Childcare bulk surname validation with the supported accented-character set already used by single checks.
* Reuses `NameAttribute.NameValidationRegex` instead of the previous rule that only excluded digits.
* Updates the validation message to correctly describe invalid characters.
* Preserves support for straight and curly apostrophes and hyphens.
* Adds automated coverage for EYPP and Two-Year Offer bulk validation.

Working Families requires no change because its bulk template does not contain a surname field.

## Testing

* New surname-validation tests: 9 passed.
* Full test suite: 159 passed.

Manual verification completed for:

* Early Years Pupil Premium
* Two-Year Offer

Confirmed that `García` is accepted and processed, `Smith@` receives an invalid-character message, and an empty surname receives the required-field message.
