### PR TITLE
ELIG-3194 Display childcare batch results in uploaded order

### DIFF
--- a/CheckChildcareEligibility.Admin.Tests/Boundary/Responses/CheckEligibilityBulkResponseTests.cs
+++ b/CheckChildcareEligibility.Admin.Tests/Boundary/Responses/CheckEligibilityBulkResponseTests.cs
@@ -1,0 +1,72 @@
+﻿using CheckChildcareEligibility.Admin.Boundary.Responses;
+using CheckChildcareEligibility.Admin.Models;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace CheckChildcareEligibility.Admin.Tests.Boundary.Responses;
+
+[TestFixture]
+public class CheckEligibilityBulkResponseTests
+{
+    [Test]
+    public void BulkDataMapper_StandardResults_ReturnsRowsInUploadedOrder()
+    {
+        var response = new CheckEligibilityBulkResponse
+        {
+            Data =
+            [
+                new CheckEligibilityItem
+                {
+                    Order = 2,
+                    LastName = "SECOND",
+                    Status = "eligible"
+                },
+                new CheckEligibilityItem
+                {
+                    Order = 1,
+                    LastName = "FIRST",
+                    Status = "eligible"
+                }
+            ]
+        };
+
+        var result = response.BulkDataMapper()
+            .Cast<BulkExport>()
+            .ToList();
+
+        result.Select(x => x.LastName)
+            .Should()
+            .Equal("FIRST", "SECOND");
+    }
+
+    [Test]
+    public void BulkDataMapper_WorkingFamiliesResults_ReturnsRowsInUploadedOrder()
+    {
+        var response = new CheckEligibilityBulkWorkingFamiliesResponse
+        {
+            Data =
+            [
+                new CheckEligibilityItemWorkingFamilies
+                {
+                    Order = 2,
+                    EligibilityCode = "SECOND",
+                    Status = "eligible"
+                },
+                new CheckEligibilityItemWorkingFamilies
+                {
+                    Order = 1,
+                    EligibilityCode = "FIRST",
+                    Status = "eligible"
+                }
+            ]
+        };
+
+        var result = response.BulkDataMapper()
+            .Cast<BulkExportWorkingFamilies>()
+            .ToList();
+
+        result.Select(x => x.EligibilityCode)
+            .Should()
+            .Equal("FIRST", "SECOND");
+    }
+}

--- a/CheckChildcareEligibility.Admin.Tests/Controllers/BulkCheckControllerTests.cs
+++ b/CheckChildcareEligibility.Admin.Tests/Controllers/BulkCheckControllerTests.cs
@@ -182,7 +182,7 @@ namespace CheckChildcareEligibility.Admin.Tests.Controllers
                 new CheckEligibilityRequestData() 
                 {
                     Type = CheckEligibilityType.TwoYearOffer,
-                    Sequence = 1, 
+                    Order = 1, 
                     DateOfBirth = "2017-01-01", 
                     LastName = "Test", 
                     NationalInsuranceNumber = "ab"
@@ -315,7 +315,7 @@ namespace CheckChildcareEligibility.Admin.Tests.Controllers
                 new CheckEligibilityRequestData() {
 
                     Type = CheckEligibilityType.TwoYearOffer,
-                    Sequence = 1, 
+                    Order = 1, 
                     DateOfBirth = "2017-01-01", 
                     LastName = "Test", 
                     NationalInsuranceNumber = "ab" }
@@ -413,7 +413,7 @@ namespace CheckChildcareEligibility.Admin.Tests.Controllers
                 new CheckEligibilityRequestData()
                 {
                     Type = CheckEligibilityType.TwoYearOffer,
-                    Sequence = 1,
+                    Order = 1,
                     DateOfBirth = "2017-01-01",
                     LastName = "Test",
                     NationalInsuranceNumber = "ab"
@@ -486,7 +486,7 @@ namespace CheckChildcareEligibility.Admin.Tests.Controllers
             {
                 new CheckEligibilityRequestData() { 
                     Type = CheckEligibilityType.TwoYearOffer,
-                    Sequence = 1, 
+                    Order = 1, 
                     DateOfBirth = "2017-01-01", 
                     LastName = "Test", 
                     NationalInsuranceNumber = "ab" }

--- a/CheckChildcareEligibility.Admin.Tests/Usecases/ParseBulkCheckFileUseCaseTests.cs
+++ b/CheckChildcareEligibility.Admin.Tests/Usecases/ParseBulkCheckFileUseCaseTests.cs
@@ -276,7 +276,7 @@ namespace CheckChildcareEligibility.Admin.Tests.Usecases
         }
 
         [Test]
-        public async Task Given_Bulk_Check_When_FileData_Contains_Valid_Data_Rows_Should_Return_Valid_Results_with_Sequence()
+        public async Task Given_Bulk_Check_When_FileData_Contains_Valid_Data_Rows_Should_Return_Valid_Results_with_Order()
         {
             // Arrange
             var errors = new List<CsvRowError>();
@@ -307,7 +307,7 @@ namespace CheckChildcareEligibility.Admin.Tests.Usecases
             var sequence = 1;
             foreach (var request in result.ValidRequests)
             {
-                request.Sequence.Should().Be(sequence);
+                request.Order.Should().Be(sequence);
                 sequence++;
             }
         }

--- a/CheckChildcareEligibility.Admin/Boundary/Requests/CheckEligibilityRequestDataBase.cs
+++ b/CheckChildcareEligibility.Admin/Boundary/Requests/CheckEligibilityRequestDataBase.cs
@@ -5,7 +5,7 @@ namespace CheckChildcareEligibility.Admin.Boundary.Requests;
 public class CheckEligibilityRequestDataBase : IEligibilityServiceType
 {
     public CheckEligibilityType Type { get; set; }
-    public int? Sequence { get; set; }
+    public int? Order { get; set; }
     public string DateOfBirth { get; set; } = string.Empty;
     public string NationalInsuranceNumber { get; set; } = string.Empty;
 }

--- a/CheckChildcareEligibility.Admin/Boundary/Responses/CheckEligibilityBulkResponse.cs
+++ b/CheckChildcareEligibility.Admin/Boundary/Responses/CheckEligibilityBulkResponse.cs
@@ -32,7 +32,7 @@ public class CheckEligibilityBulkResponse : CheckEligibilityBulkResponseBase
     }
     public override IEnumerable<IBulkExport> BulkDataMapper() {
 
-        return Data.Select(x => new BulkExport
+        return Data.OrderBy(x => x.Order).Select(x => new BulkExport
         {
             LastName = x.LastName,
             DOB = x.DateOfBirth,
@@ -67,7 +67,7 @@ public class CheckEligibilityBulkWorkingFamiliesResponse : CheckEligibilityBulkR
     public override IEnumerable<IBulkExport> BulkDataMapper()
     {
 
-        return Data.Select(x => new BulkExportWorkingFamilies
+        return Data.OrderBy(x => x.Order).Select(x => new BulkExportWorkingFamilies
         {
             EligibilityCode = x.EligibilityCode,
             ChildDOB = x.DateOfBirth,

--- a/CheckChildcareEligibility.Admin/Boundary/Responses/CheckEligibilityItemResponse.cs
+++ b/CheckChildcareEligibility.Admin/Boundary/Responses/CheckEligibilityItemResponse.cs
@@ -18,6 +18,8 @@ public class CheckEligibilityItem
     public string Status { get; set; }
 
     public DateTime Created { get; set; }
+
+    public int? Order { get; set; }
 }
 
 public class CheckEligibilityItemResponse : CheckEligibilityItemResponseBase
@@ -38,6 +40,7 @@ public class CheckEligibilityItemWorkingFamilies
     public string ValidityStartDate { get; set; }
     public string ValidityEndDate { get; set; }
     public string GracePeriodEndDate { get; set; }
+    public int? Order { get; set; }
 }
 public class CheckEligibilityItemWorkingFamiliesResponse : CheckEligibilityItemResponseBase
 {

--- a/CheckChildcareEligibility.Admin/Usecases/ParseBulkCheckFileUseCase.cs
+++ b/CheckChildcareEligibility.Admin/Usecases/ParseBulkCheckFileUseCase.cs
@@ -144,7 +144,7 @@ namespace CheckChildcareEligibility.Admin.Usecases
                                 requestDataWF.DateOfBirth = workingFamilyRow.DOB;//must remain in original pre-parsed form to go through validator
                                 requestDataWF.NationalInsuranceNumber = workingFamilyRow.Ni.ToUpper().Replace(" ", "");
                                 requestDataWF.Type = eligibilityType;
-                                requestDataWF.Sequence = sequence;
+                                requestDataWF.Order = sequence;
                                 validationResults = _validator.Validate(requestDataWF);
                                 if (validationResults.IsValid) {
                                     //We know this passed parse earlier but it must be translated to correct format (yyyy-MM-dd) for Database to access
@@ -159,7 +159,7 @@ namespace CheckChildcareEligibility.Admin.Usecases
                                 requestData.DateOfBirth = row.DOB;//must remain in original pre-parsed form to go through validator
                                 requestData.NationalInsuranceNumber = row.Ni.ToUpper().Replace(" ", "");
                                 requestData.Type = eligibilityType;
-                                requestData.Sequence = sequence;
+                                requestData.Order = sequence;
                                 validationResults = _validator.Validate(requestData);
                                 if (validationResults.IsValid)
                                 {


### PR DESCRIPTION
## Summary

- Replaces the obsolete frontend `Sequence` property with the new internal `Order` value.
- Assigns `Order` from the original CSV row position during upload parsing.
- Reads `Order` from completed API bulk results.
- Sorts EYPP, EL2 and Working Families results by `Order` before mapping them to the outcome CSV.
- Does not add an Order column to the downloaded CSV.

## Reason

Asynchronous processing can return batch results in a different order from the uploaded file. Local authorities need the outcome rows to match their original upload order so they can reliably align the results with their own records.

## Testing

- Full Childcare Admin unit-test suite: 152 passed
- 0 failed
- 0 skipped
- Added regression coverage for standard EYPP/EL2 and Working Families result ordering.
- Existing upload parsing coverage updated to verify `Order`.

## Dependency

Depends on the supporting API change:

- [eligibility-checking-engine #529](https://github.com/DFE-Digital/eligibility-checking-engine/pull/529)

The API change must be deployed before, or alongside, this frontend change.